### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0](https://github.com/oxibus/dbc-codegen/compare/v0.3.0...v0.4.0) - 2026-07-21
+
+### Added
+
+- optional padding bit value ([#184](https://github.com/oxibus/dbc-codegen/pull/184))
+- add `DBC_FILE_NAME` + ver, proper code formatting ([#131](https://github.com/oxibus/dbc-codegen/pull/131))
+- [**breaking**] streamline DBC code generation and file writing ([#128](https://github.com/oxibus/dbc-codegen/pull/128))
+
+### Fixed
+
+- support large min/max values without precision loss ([#152](https://github.com/oxibus/dbc-codegen/pull/152))
+- handle duplicate signal names ([#126](https://github.com/oxibus/dbc-codegen/pull/126))
+- handle empty relevant msgs in from_can_message ([#125](https://github.com/oxibus/dbc-codegen/pull/125))
+- fix typo
+- fix formatting errors
+- fix factor/offset not getting applied to 0 for unsigned case
+- fix duplicate enum names on multiplex messages
+- fix issue where signed signals would be rendered as unsigned
+
+### Other
+
+- Generate enum-typed setters and constructors for signals with value descriptions ([#178](https://github.com/oxibus/dbc-codegen/pull/178))
+- Emit MESSAGE_CYCLE_TIME as integer ([#186](https://github.com/oxibus/dbc-codegen/pull/186))
+- Generate message size and cycle time consts ([#176](https://github.com/oxibus/dbc-codegen/pull/176))
+- Add option to generate typed constants from DBC attributes ([#175](https://github.com/oxibus/dbc-codegen/pull/175))
+- update can-dbc ([#181](https://github.com/oxibus/dbc-codegen/pull/181))
+- rust ver bump ([#182](https://github.com/oxibus/dbc-codegen/pull/182))
+- cleanup clippy, justfile, and proj cleanup ([#180](https://github.com/oxibus/dbc-codegen/pull/180))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#172](https://github.com/oxibus/dbc-codegen/pull/172))
+- *(deps)* bump codecov/codecov-action from 6 to 7 in the all-actions-version-updates group ([#165](https://github.com/oxibus/dbc-codegen/pull/165))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#168](https://github.com/oxibus/dbc-codegen/pull/168))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 3 updates ([#163](https://github.com/oxibus/dbc-codegen/pull/163))
+- *(deps)* bump the all-cargo-version-updates group with 2 updates ([#161](https://github.com/oxibus/dbc-codegen/pull/161))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#158](https://github.com/oxibus/dbc-codegen/pull/158))
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#159](https://github.com/oxibus/dbc-codegen/pull/159))
+- update expected errors to Rust 1.94 ([#153](https://github.com/oxibus/dbc-codegen/pull/153))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#145](https://github.com/oxibus/dbc-codegen/pull/145))
+- *(deps)* bump insta from 1.46.2 to 1.46.3 in the all-cargo-version-updates group ([#143](https://github.com/oxibus/dbc-codegen/pull/143))
+- upgrade to rust 1.93 stderr ([#142](https://github.com/oxibus/dbc-codegen/pull/142))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#141](https://github.com/oxibus/dbc-codegen/pull/141))
+- [**breaking**] remove main fn from generated code ([#138](https://github.com/oxibus/dbc-codegen/pull/138))
+- make many rendering fn methods on config ([#133](https://github.com/oxibus/dbc-codegen/pull/133))
+- *(deps)* bump clap from 4.5.54 to 4.5.55 in the all-cargo-version-updates group ([#134](https://github.com/oxibus/dbc-codegen/pull/134))
+- use `quote` crate to handle str escaping ([#132](https://github.com/oxibus/dbc-codegen/pull/132))
+- noop - dedup, cleanup, new type abstraction ([#130](https://github.com/oxibus/dbc-codegen/pull/130))
+- update shared tests, bump deps, freeze to rust 1.92  ([#127](https://github.com/oxibus/dbc-codegen/pull/127))
+- *(deps)* bump can-dbc from 8.0.0 to 8.0.1 in the all-cargo-version-updates group ([#129](https://github.com/oxibus/dbc-codegen/pull/129))
+- do not clean lock
+- bump dependencies and enable verbose output for release actions ([#120](https://github.com/oxibus/dbc-codegen/pull/120))
+- [pre-commit.ci] pre-commit autoupdate ([#119](https://github.com/oxibus/dbc-codegen/pull/119))
+- Bump the all-cargo-version-updates group across 1 directory with 2 updates ([#118](https://github.com/oxibus/dbc-codegen/pull/118))
+- refactor write functions, improve CI, MSRV ([#116](https://github.com/oxibus/dbc-codegen/pull/116))
+- minor code cleanup ([#114](https://github.com/oxibus/dbc-codegen/pull/114))
+- generate and compile all .dbc files from test repo ([#113](https://github.com/oxibus/dbc-codegen/pull/113))
+- allow generated file to be used with `include!` ([#108](https://github.com/oxibus/dbc-codegen/pull/108))
+- Bump the all-cargo-version-updates group across 1 directory with 2 updates ([#111](https://github.com/oxibus/dbc-codegen/pull/111))
+- minor justfile fix, editorconfig ([#112](https://github.com/oxibus/dbc-codegen/pull/112))
+- Bump actions/cache from 4 to 5 in the all-actions-version-updates group ([#110](https://github.com/oxibus/dbc-codegen/pull/110))
+- OxiBUS onboarding cleanup ([#102](https://github.com/oxibus/dbc-codegen/pull/102))
+- run `just fmt` to cleanup imports ([#107](https://github.com/oxibus/dbc-codegen/pull/107))
+- Bump the all-cargo-version-updates group across 1 directory with 9 updates ([#106](https://github.com/oxibus/dbc-codegen/pull/106))
+- upgrade to can-dbc v8 ([#101](https://github.com/oxibus/dbc-codegen/pull/101))
+- Bump actions/checkout from 1 to 6 in the all-actions-version-updates group ([#104](https://github.com/oxibus/dbc-codegen/pull/104))
+- *(CI)* minor CI updates, automate dependabot ([#103](https://github.com/oxibus/dbc-codegen/pull/103))
+- Add optional defmt::Format support for generated types
+- Merge pull request #85 from inomotech-foss/fix-mux-msg-id
+- Use message name instead of self
+- Generate embedded_can::Frame trait for each frame
+- Represent CAN message IDs as embedded_can::Id to support extended IDs
+- Fix issue with decoding signed values of non-standard length
+- revert change to Cargo.toml, not necessary
+- address clippy's concerns (thanks clippy), enhance comments
+- make can-messages dependency optional so it doesn't pull in std
+- reduce diff against main
+- handle more edge cases, use i128 as the maximum type
+- reorder lines to match signals
+- drop symlink in favor of copy so it works on Windows
+- revert because I missed the case of check_ranges being false
+- add tests, edge cases where the min/max is way less than signal width
+- clean up warning
+- add unsigned to the name, add test case
+- change signal logic to handle negative factors, add tests
+- Bump rustc to latest stable, 1.78
+- Merge pull request #68 from projectgus/tweaks/codegen_warnings
+- Rename .envrc for non-Nix users, add note in README
+- dont assign signed integers to unsigned integers
+- Update README
+- Fix clippy warnings
+- Use checked_sub(offset) for set_signal methods
+- Don't treat signals as floats if factor is integer
+- Add flag to impl std Error
+- Tweak docs and optional features
+- Make feature-gated impls configurable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -105,7 +105,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -248,14 +248,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "dbc-codegen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -293,7 +293,7 @@ dependencies = [
  "insta",
  "prettyplease",
  "quote",
- "syn",
+ "syn 2.0.119",
  "test_each_file",
  "trybuild",
  "typed-builder",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "dbc-codegen-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "dbc-codegen",
@@ -328,7 +328,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -394,9 +394,9 @@ checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -484,9 +484,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libloading"
@@ -589,7 +589,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -608,23 +608,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -719,29 +719,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -795,6 +795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,9 +813,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -836,28 +847,28 @@ checksum = "44619e49a1f62888c271dc50533f036363a7936f99c7cb467ca9d45224cf83b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -931,7 +942,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbc-codegen"
-version = "0.3.0"
+version = "0.4.0"
 description = "CAN DBC code-gen for embedded Rust"
 authors = [
     "Pascal Hertleif <pascal@technocreatives.com>",

--- a/dbc-codegen-cli/CHANGELOG.md
+++ b/dbc-codegen-cli/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0](https://github.com/oxibus/dbc-codegen/compare/v0.3.0...v0.4.0) - 2026-07-21
+
+### Added
+
+- [**breaking**] streamline DBC code generation and file writing ([#128](https://github.com/oxibus/dbc-codegen/pull/128))
+
+### Other
+
+- Generate message size and cycle time consts ([#176](https://github.com/oxibus/dbc-codegen/pull/176))
+- Add option to generate typed constants from DBC attributes ([#175](https://github.com/oxibus/dbc-codegen/pull/175))
+- cleanup clippy, justfile, and proj cleanup ([#180](https://github.com/oxibus/dbc-codegen/pull/180))
+- *(deps)* bump the all-cargo-version-updates group with 2 updates ([#161](https://github.com/oxibus/dbc-codegen/pull/161))
+- minor code cleanup ([#114](https://github.com/oxibus/dbc-codegen/pull/114))
+- allow generated file to be used with `include!` ([#108](https://github.com/oxibus/dbc-codegen/pull/108))
+- OxiBUS onboarding cleanup ([#102](https://github.com/oxibus/dbc-codegen/pull/102))
+- run `just fmt` to cleanup imports ([#107](https://github.com/oxibus/dbc-codegen/pull/107))
+- Bump the all-cargo-version-updates group across 1 directory with 9 updates ([#106](https://github.com/oxibus/dbc-codegen/pull/106))
+- upgrade to can-dbc v8 ([#101](https://github.com/oxibus/dbc-codegen/pull/101))
+- make debug_prints configurable
+- Merge pull request #68 from projectgus/tweaks/codegen_warnings
+- Rename .envrc for non-Nix users, add note in README
+- Update README
+- Make feature-gated impls configurable

--- a/dbc-codegen-cli/Cargo.toml
+++ b/dbc-codegen-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbc-codegen-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "CLI for CAN DBC codegen"
 authors = [
     "Pascal Hertleif <pascal@technocreatives.com>",
@@ -21,5 +21,5 @@ doc = false
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
-dbc-codegen = { version = "0.3", path = ".." }
+dbc-codegen = { version = "0.4", path = ".." }
 exitcode = "1.1.2"


### PR DESCRIPTION



## 🤖 New release

* `dbc-codegen`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `dbc-codegen-cli`: 0.3.0 -> 0.4.0

### ⚠ `dbc-codegen` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron

Failed in:
  function dbc_codegen::codegen, previously in file /tmp/.tmp0XWOqx/dbc-codegen/src/lib.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `dbc-codegen`

<blockquote>

## [0.4.0](https://github.com/oxibus/dbc-codegen/compare/v0.3.0...v0.4.0) - 2026-09-22

### Added

- *(fuzz)* make fuzz compile/run ([#140](https://github.com/oxibus/dbc-codegen/pull/140))
- optional padding bit value ([#184](https://github.com/oxibus/dbc-codegen/pull/184))
- add `DBC_FILE_NAME` + ver, proper code formatting ([#131](https://github.com/oxibus/dbc-codegen/pull/131))
- [**breaking**] streamline DBC code generation and file writing ([#128](https://github.com/oxibus/dbc-codegen/pull/128))

### Fixed

- support large min/max values without precision loss ([#152](https://github.com/oxibus/dbc-codegen/pull/152))
- handle duplicate signal names ([#126](https://github.com/oxibus/dbc-codegen/pull/126))
- handle empty relevant msgs in from_can_message ([#125](https://github.com/oxibus/dbc-codegen/pull/125))
- fix typo
- fix formatting errors
- fix factor/offset not getting applied to 0 for unsigned case
- fix duplicate enum names on multiplex messages
- fix issue where signed signals would be rendered as unsigned

### Other

- 2024 edition, bump deps, minor fixes ([#196](https://github.com/oxibus/dbc-codegen/pull/196))
- [pre-commit.ci] pre-commit autoupdate ([#189](https://github.com/oxibus/dbc-codegen/pull/189))
- *(deps)* bump actions/checkout from 6 to 7 in the all-actions-version-updates group across 1 directory ([#191](https://github.com/oxibus/dbc-codegen/pull/191))
- Remove unsafe from generated MESSAGE_ID constants ([#194](https://github.com/oxibus/dbc-codegen/pull/194))
- Generate raw signal getters and setters ([#193](https://github.com/oxibus/dbc-codegen/pull/193))
- Support relation attributes in attribute_structs ([#192](https://github.com/oxibus/dbc-codegen/pull/192))
- Generate enum-typed setters and constructors for signals with value descriptions ([#178](https://github.com/oxibus/dbc-codegen/pull/178))
- Emit MESSAGE_CYCLE_TIME as integer ([#186](https://github.com/oxibus/dbc-codegen/pull/186))
- Generate message size and cycle time consts ([#176](https://github.com/oxibus/dbc-codegen/pull/176))
- Add option to generate typed constants from DBC attributes ([#175](https://github.com/oxibus/dbc-codegen/pull/175))
- update can-dbc ([#181](https://github.com/oxibus/dbc-codegen/pull/181))
- rust ver bump ([#182](https://github.com/oxibus/dbc-codegen/pull/182))
- cleanup clippy, justfile, and proj cleanup ([#180](https://github.com/oxibus/dbc-codegen/pull/180))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#172](https://github.com/oxibus/dbc-codegen/pull/172))
- *(deps)* bump codecov/codecov-action from 6 to 7 in the all-actions-version-updates group ([#165](https://github.com/oxibus/dbc-codegen/pull/165))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#168](https://github.com/oxibus/dbc-codegen/pull/168))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 3 updates ([#163](https://github.com/oxibus/dbc-codegen/pull/163))
- *(deps)* bump the all-cargo-version-updates group with 2 updates ([#161](https://github.com/oxibus/dbc-codegen/pull/161))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#158](https://github.com/oxibus/dbc-codegen/pull/158))
- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#159](https://github.com/oxibus/dbc-codegen/pull/159))
- update expected errors to Rust 1.94 ([#153](https://github.com/oxibus/dbc-codegen/pull/153))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#145](https://github.com/oxibus/dbc-codegen/pull/145))
- *(deps)* bump insta from 1.46.2 to 1.46.3 in the all-cargo-version-updates group ([#143](https://github.com/oxibus/dbc-codegen/pull/143))
- upgrade to rust 1.93 stderr ([#142](https://github.com/oxibus/dbc-codegen/pull/142))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 4 updates ([#141](https://github.com/oxibus/dbc-codegen/pull/141))
- [**breaking**] remove main fn from generated code ([#138](https://github.com/oxibus/dbc-codegen/pull/138))
- make many rendering fn methods on config ([#133](https://github.com/oxibus/dbc-codegen/pull/133))
- *(deps)* bump clap from 4.5.54 to 4.5.55 in the all-cargo-version-updates group ([#134](https://github.com/oxibus/dbc-codegen/pull/134))
- use `quote` crate to handle str escaping ([#132](https://github.com/oxibus/dbc-codegen/pull/132))
- noop - dedup, cleanup, new type abstraction ([#130](https://github.com/oxibus/dbc-codegen/pull/130))
- update shared tests, bump deps, freeze to rust 1.92  ([#127](https://github.com/oxibus/dbc-codegen/pull/127))
- *(deps)* bump can-dbc from 8.0.0 to 8.0.1 in the all-cargo-version-updates group ([#129](https://github.com/oxibus/dbc-codegen/pull/129))
- do not clean lock
- bump dependencies and enable verbose output for release actions ([#120](https://github.com/oxibus/dbc-codegen/pull/120))
- [pre-commit.ci] pre-commit autoupdate ([#119](https://github.com/oxibus/dbc-codegen/pull/119))
- Bump the all-cargo-version-updates group across 1 directory with 2 updates ([#118](https://github.com/oxibus/dbc-codegen/pull/118))
- refactor write functions, improve CI, MSRV ([#116](https://github.com/oxibus/dbc-codegen/pull/116))
- minor code cleanup ([#114](https://github.com/oxibus/dbc-codegen/pull/114))
- generate and compile all .dbc files from test repo ([#113](https://github.com/oxibus/dbc-codegen/pull/113))
- allow generated file to be used with `include!` ([#108](https://github.com/oxibus/dbc-codegen/pull/108))
- Bump the all-cargo-version-updates group across 1 directory with 2 updates ([#111](https://github.com/oxibus/dbc-codegen/pull/111))
- minor justfile fix, editorconfig ([#112](https://github.com/oxibus/dbc-codegen/pull/112))
- Bump actions/cache from 4 to 5 in the all-actions-version-updates group ([#110](https://github.com/oxibus/dbc-codegen/pull/110))
- OxiBUS onboarding cleanup ([#102](https://github.com/oxibus/dbc-codegen/pull/102))
- run `just fmt` to cleanup imports ([#107](https://github.com/oxibus/dbc-codegen/pull/107))
- Bump the all-cargo-version-updates group across 1 directory with 9 updates ([#106](https://github.com/oxibus/dbc-codegen/pull/106))
- upgrade to can-dbc v8 ([#101](https://github.com/oxibus/dbc-codegen/pull/101))
- Bump actions/checkout from 1 to 6 in the all-actions-version-updates group ([#104](https://github.com/oxibus/dbc-codegen/pull/104))
- *(CI)* minor CI updates, automate dependabot ([#103](https://github.com/oxibus/dbc-codegen/pull/103))
- Add optional defmt::Format support for generated types
- Merge pull request #85 from inomotech-foss/fix-mux-msg-id
- Use message name instead of self
- Generate embedded_can::Frame trait for each frame
- Represent CAN message IDs as embedded_can::Id to support extended IDs
- Fix issue with decoding signed values of non-standard length
- revert change to Cargo.toml, not necessary
- address clippy's concerns (thanks clippy), enhance comments
- make can-messages dependency optional so it doesn't pull in std
- reduce diff against main
- handle more edge cases, use i128 as the maximum type
- reorder lines to match signals
- drop symlink in favor of copy so it works on Windows
- revert because I missed the case of check_ranges being false
- add tests, edge cases where the min/max is way less than signal width
- clean up warning
- add unsigned to the name, add test case
- change signal logic to handle negative factors, add tests
- Bump rustc to latest stable, 1.78
- Merge pull request #68 from projectgus/tweaks/codegen_warnings
- Rename .envrc for non-Nix users, add note in README
- dont assign signed integers to unsigned integers
- Update README
- Fix clippy warnings
- Use checked_sub(offset) for set_signal methods
- Don't treat signals as floats if factor is integer
- Add flag to impl std Error
- Tweak docs and optional features
- Make feature-gated impls configurable
</blockquote>

## `dbc-codegen-cli`

<blockquote>

## [0.4.0](https://github.com/oxibus/dbc-codegen/compare/v0.3.0...v0.4.0) - 2026-09-22

### Added

- [**breaking**] streamline DBC code generation and file writing ([#128](https://github.com/oxibus/dbc-codegen/pull/128))

### Other

- 2024 edition, bump deps, minor fixes ([#196](https://github.com/oxibus/dbc-codegen/pull/196))
- Generate raw signal getters and setters ([#193](https://github.com/oxibus/dbc-codegen/pull/193))
- Support relation attributes in attribute_structs ([#192](https://github.com/oxibus/dbc-codegen/pull/192))
- Generate message size and cycle time consts ([#176](https://github.com/oxibus/dbc-codegen/pull/176))
- Add option to generate typed constants from DBC attributes ([#175](https://github.com/oxibus/dbc-codegen/pull/175))
- cleanup clippy, justfile, and proj cleanup ([#180](https://github.com/oxibus/dbc-codegen/pull/180))
- *(deps)* bump the all-cargo-version-updates group with 2 updates ([#161](https://github.com/oxibus/dbc-codegen/pull/161))
- minor code cleanup ([#114](https://github.com/oxibus/dbc-codegen/pull/114))
- allow generated file to be used with `include!` ([#108](https://github.com/oxibus/dbc-codegen/pull/108))
- OxiBUS onboarding cleanup ([#102](https://github.com/oxibus/dbc-codegen/pull/102))
- run `just fmt` to cleanup imports ([#107](https://github.com/oxibus/dbc-codegen/pull/107))
- Bump the all-cargo-version-updates group across 1 directory with 9 updates ([#106](https://github.com/oxibus/dbc-codegen/pull/106))
- upgrade to can-dbc v8 ([#101](https://github.com/oxibus/dbc-codegen/pull/101))
- make debug_prints configurable
- Merge pull request #68 from projectgus/tweaks/codegen_warnings
- Rename .envrc for non-Nix users, add note in README
- Update README
- Make feature-gated impls configurable
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).