### PR TITLE
Remove unsafe from generated MESSAGE_ID constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,11 +368,10 @@ impl Config<'_> {
                 w,
                 "pub const MESSAGE_ID: embedded_can::Id = {};",
                 match msg.id {
-                    // use StandardId::new().unwrap() once const_option is stable
                     MessageId::Standard(id) =>
-                        format!("Id::Standard(unsafe {{ StandardId::new_unchecked({id:#x})}})"),
+                        format!("Id::Standard(StandardId::new({id:#x}).unwrap())"),
                     MessageId::Extended(id) =>
-                        format!("Id::Extended(unsafe {{ ExtendedId::new_unchecked({id:#x})}})"),
+                        format!("Id::Extended(ExtendedId::new({id:#x}).unwrap())"),
                 }
             )?;
             writeln!(w)?;

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -57,10 +57,10 @@ BO_ 1338 LargerIntsWithOffsets: 8 Sit
 
 BO_ 513 MsgWithoutSignals: 8 Ipsum
 
-BO_ 9001 TruncatedBeSignal: 8 Ipsum
+BO_ 809 TruncatedBeSignal: 8 Ipsum
   SG_ Foo : 0|12@0- (1,0) [-100|100] "" Vector__XXX
 
-BO_ 9002 TruncatedLeSignal: 8 Ipsum
+BO_ 810 TruncatedLeSignal: 8 Ipsum
   SG_ Foo : 0|12@1- (1,0) [-100|100] "" Vector__XXX
 
 BO_ 2147488308 MsgExtendedId: 8 Sit

--- a/tests-snapshots/canpy/DBC_template.snap.rs
+++ b/tests-snapshots/canpy/DBC_template.snap.rs
@@ -73,9 +73,9 @@ pub struct CanMultiplexed {
     unused_variables,
 )]
 impl CanMultiplexed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x10e1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x10e1).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const VALUE1_MIN: u8 = 0_u8;
     pub const VALUE1_MAX: u8 = 0_u8;
@@ -448,9 +448,9 @@ pub struct CanMessage {
     unused_variables,
 )]
 impl CanMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4d2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x4d2).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: u64 = 0_u64;
     pub const SIGNAL1_MAX: u64 = 100_u64;

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
@@ -64,9 +64,7 @@ pub struct Control {
     unused_variables,
 )]
 impl Control {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 7;
     pub const STATE_MIN: u8 = 0_u8;
     pub const STATE_MAX: u8 = 100_u8;

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
@@ -64,9 +64,7 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 7;
     pub const SIGNAL_1_MIN: u8 = 0_u8;
     pub const SIGNAL_1_MAX: u8 = 100_u8;

--- a/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
+++ b/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
@@ -64,9 +64,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     /// Constructs a new `Message1` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/abs.snap.rs
+++ b/tests-snapshots/dbc-cantools/abs.snap.rs
@@ -115,9 +115,9 @@ pub struct Bremse33 {
     unused_variables,
 )]
 impl Bremse33 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x343)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x343).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const WHLSPEED_FL_MIN: f32 = 0_f32;
     pub const WHLSPEED_FL_MAX: f32 = 100_f32;
@@ -387,9 +387,9 @@ pub struct Bremse10 {
     unused_variables,
 )]
 impl Bremse10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x140)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x140).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `BREMSE_10` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -458,9 +458,9 @@ pub struct Bremse11 {
     unused_variables,
 )]
 impl Bremse11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x141)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x141).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `BREMSE_11` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -529,9 +529,9 @@ pub struct Bremse12 {
     unused_variables,
 )]
 impl Bremse12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x142)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x142).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `BREMSE_12` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -600,9 +600,9 @@ pub struct Bremse13 {
     unused_variables,
 )]
 impl Bremse13 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x143)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x143).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `BREMSE_13` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -671,9 +671,9 @@ pub struct DrsRxId0 {
     unused_variables,
 )]
 impl DrsRxId0 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x75)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x75).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `DRS_RX_ID0` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -742,9 +742,9 @@ pub struct Mm510Tx1 {
     unused_variables,
 )]
 impl Mm510Tx1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x70)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x70).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const YAW_RATE_MIN: f32 = -163.84_f32;
     pub const YAW_RATE_MAX: f32 = 163.83_f32;
@@ -911,9 +911,9 @@ pub struct Mm510Tx2 {
     unused_variables,
 )]
 impl Mm510Tx2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x80)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x80).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ROLL_RATE_MIN: f32 = -163.84_f32;
     pub const ROLL_RATE_MAX: f32 = 163.835_f32;
@@ -1080,9 +1080,9 @@ pub struct Mm510Tx3 {
     unused_variables,
 )]
 impl Mm510Tx3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x576)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x576).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const AZ_MIN: f32 = -4.1768_f32;
     pub const AZ_MAX: f32 = 4.1765_f32;
@@ -1200,9 +1200,9 @@ pub struct Bremse2 {
     unused_variables,
 )]
 impl Bremse2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x24a)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x24a).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const WHLSPEED_FL_BREMSE2_MIN: f32 = 0_f32;
     pub const WHLSPEED_FL_BREMSE2_MAX: f32 = 100_f32;
@@ -1471,9 +1471,9 @@ pub struct AbsSwitch {
     unused_variables,
 )]
 impl AbsSwitch {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x24c)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x24c).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ABS_SWITCHPOSITION_MIN: u8 = 0_u8;
     pub const ABS_SWITCHPOSITION_MAX: u8 = 11_u8;
@@ -1585,9 +1585,9 @@ pub struct Bremse30 {
     unused_variables,
 )]
 impl Bremse30 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x340)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x340).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `BREMSE_30` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -1656,9 +1656,9 @@ pub struct Bremse31 {
     unused_variables,
 )]
 impl Bremse31 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x341)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x341).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IDLE_TIME_MIN: u16 = 0_u16;
     pub const IDLE_TIME_MAX: u16 = 0_u16;
@@ -1768,9 +1768,9 @@ pub struct Bremse32 {
     unused_variables,
 )]
 impl Bremse32 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x342)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x342).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_FA_MIN: f32 = 0_f32;
     pub const ACC_FA_MAX: f32 = 10_f32;
@@ -2148,9 +2148,9 @@ pub struct Bremse51 {
     unused_variables,
 )]
 impl Bremse51 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x541)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x541).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const AX1_ABS_INT_MIN: f32 = -4.1768_f32;
     pub const AX1_ABS_INT_MAX: f32 = 4.1736697_f32;
@@ -2452,9 +2452,9 @@ pub struct Bremse52 {
     unused_variables,
 )]
 impl Bremse52 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x542)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x542).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MPLX_SW_INFO_MIN: u8 = 0_u8;
     pub const MPLX_SW_INFO_MAX: u8 = 255_u8;
@@ -4430,9 +4430,9 @@ pub struct Bremse50 {
     unused_variables,
 )]
 impl Bremse50 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x560)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x560).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const BRAKE_BAL_AT50_MIN: f32 = 0_f32;
     pub const BRAKE_BAL_AT50_MAX: f32 = 100_f32;
@@ -4690,9 +4690,9 @@ pub struct Bremse53 {
     unused_variables,
 )]
 impl Bremse53 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5c0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x5c0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SWITCH_POSITION_MIN: u8 = 1_u8;
     pub const SWITCH_POSITION_MAX: u8 = 12_u8;

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
@@ -67,9 +67,7 @@ pub struct M1 {
     unused_variables,
 )]
 impl M1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `M1` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -138,9 +136,7 @@ pub struct M2 {
     unused_variables,
 )]
 impl M2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `M2` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
@@ -64,9 +64,7 @@ pub struct M1 {
     unused_variables,
 )]
 impl M1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `M1` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -66,9 +66,9 @@ pub struct Inv2EventMsg1 {
     unused_variables,
 )]
 impl Inv2EventMsg1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4d2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x4d2).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 0;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -70,9 +70,9 @@ pub struct TheMessage {
     unused_variables,
 )]
 impl TheMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x39)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x39).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
@@ -184,9 +184,9 @@ pub struct TheOtherMessage {
     unused_variables,
 )]
 impl TheOtherMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2a)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x2a).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -67,9 +67,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x53)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x53).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 50;
     pub const SIGNAL_2_MIN: i8 = 0_i8;
@@ -182,9 +182,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x52)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x52).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL_1_MIN: i8 = 0_i8;
     pub const SIGNAL_1_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -70,9 +70,9 @@ pub struct TheMessage {
     unused_variables,
 )]
 impl TheMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x39)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x39).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
@@ -184,9 +184,9 @@ pub struct TheOtherMessage {
     unused_variables,
 )]
 impl TheOtherMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2a)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x2a).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/bus_comment.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment.snap.rs
@@ -63,9 +63,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123456)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123456).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices.snap.rs
@@ -63,9 +63,7 @@ pub struct Foo {
     unused_variables,
 )]
 impl Foo {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: i8 = -128_i8;
     pub const FOO_MAX: i8 = 127_i8;

--- a/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
@@ -65,9 +65,9 @@ pub struct TestMessage {
     unused_variables,
 )]
 impl TestMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x90000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x90000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     /// Constructs a new `TestMessage` message from values.
     pub fn new(

--- a/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
+++ b/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
@@ -67,9 +67,9 @@ pub struct Msg1 {
     unused_variables,
 )]
 impl Msg1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x620)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x620).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const SIG22_MIN: u8 = 0_u8;
     pub const SIG22_MAX: u8 = 1_u8;
@@ -353,9 +353,9 @@ pub struct Msg2 {
     unused_variables,
 )]
 impl Msg2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x555)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x555).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST7_MIN: u8 = 0_u8;
     pub const TEST7_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -64,9 +64,9 @@ pub struct Message0 {
     unused_variables,
 )]
 impl Message0 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_SIGNAL_MIN: u8 = 0_u8;
     pub const FOO_SIGNAL_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/emc32.snap.rs
+++ b/tests-snapshots/dbc-cantools/emc32.snap.rs
@@ -64,9 +64,9 @@ pub struct EmvStati {
     unused_variables,
 )]
 impl EmvStati {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x222)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x222).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `EMV_Stati` message from values.
     pub fn new(

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.rs
@@ -66,9 +66,7 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xa)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0xa).unwrap());
     pub const MESSAGE_SIZE: usize = 3;
     pub const NO_CHOICE_MIN: i8 = 0_i8;
     pub const NO_CHOICE_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:314:59
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:312:59
     |
-314 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
+312 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
     |                                                           ^^^
     |
     = note: the literal `255` does not fit into the type `i8` whose range is `-128..=127`
@@ -9,9 +9,9 @@ error: literal out of range for `i8`
     = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:315:52
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:313:52
     |
-315 |             ExampleMessageNonEmptyChoice::Error => 254,
+313 |             ExampleMessageNonEmptyChoice::Error => 254,
     |                                                    ^^^
     |
     = note: the literal `254` does not fit into the type `i8` whose range is `-128..=127`

--- a/tests-snapshots/dbc-cantools/fd_test.snap.rs
+++ b/tests-snapshots/dbc-cantools/fd_test.snap.rs
@@ -78,9 +78,7 @@ pub struct TestMsgEx {
     unused_variables,
 )]
 impl TestMsgEx {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_1_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_1_MAX: i8 = 0_i8;
@@ -191,9 +189,7 @@ pub struct TestMsgStd {
     unused_variables,
 )]
 impl TestMsgStd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_3_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_3_MAX: i8 = 0_i8;
@@ -304,9 +300,7 @@ pub struct TestMsgFdStd {
     unused_variables,
 )]
 impl TestMsgFdStd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_2_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_2_MAX: i8 = 0_i8;
@@ -417,9 +411,7 @@ pub struct TestMsgFdEx {
     unused_variables,
 )]
 impl TestMsgFdEx {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/floating_point.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point.snap.rs
@@ -67,9 +67,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
@@ -181,9 +181,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x401)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x401).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i32 = 0_i32;
     pub const SIGNAL2_MAX: i32 = 0_i32;

--- a/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
@@ -70,9 +70,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
@@ -184,9 +184,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x401)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x401).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i32 = 0_i32;
     pub const SIGNAL2_MAX: i32 = 0_i32;
@@ -340,9 +340,9 @@ pub struct Message3 {
     unused_variables,
 )]
 impl Message3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x402)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x402).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL3_MIN: f32 = 0_f32;
     pub const SIGNAL3_MAX: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -78,9 +78,9 @@ pub struct Foo {
     unused_variables,
 )]
 impl Foo {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12330)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12330).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
@@ -249,9 +249,9 @@ pub struct Fum {
     unused_variables,
 )]
 impl Fum {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12331)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12331).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1;
     pub const FUM_MIN: i16 = 0_i16;
@@ -440,9 +440,9 @@ pub struct Bar {
     unused_variables,
 )]
 impl Bar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12332)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12332).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
@@ -554,9 +554,9 @@ pub struct CanFd {
     unused_variables,
 )]
 impl CanFd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12333)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12333).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 64;
     pub const FIE_MIN: u64 = 0_u64;
     pub const FIE_MAX: u64 = 0_u64;
@@ -707,9 +707,9 @@ pub struct Foobar {
     unused_variables,
 )]
 impl Foobar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x30c)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x30c).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;

--- a/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
@@ -64,9 +64,7 @@ pub struct DummyMsg {
     unused_variables,
 )]
 impl DummyMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `dummy_msg` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -78,9 +78,9 @@ pub struct Foo {
     unused_variables,
 )]
 impl Foo {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12330)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12330).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
@@ -249,9 +249,9 @@ pub struct Fum {
     unused_variables,
 )]
 impl Fum {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12331)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12331).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1;
     pub const FUM_MIN: i16 = 0_i16;
@@ -440,9 +440,9 @@ pub struct Bar {
     unused_variables,
 )]
 impl Bar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12332)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12332).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
@@ -554,9 +554,9 @@ pub struct CanFd {
     unused_variables,
 )]
 impl CanFd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x12333)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x12333).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 64;
     pub const FIE_MIN: u64 = 0_u64;
     pub const FIE_MAX: u64 = 0_u64;
@@ -707,9 +707,9 @@ pub struct Foobar {
     unused_variables,
 )]
 impl Foobar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x30c)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x30c).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
@@ -65,9 +65,7 @@ pub struct ExtMuxCascaded {
     unused_variables,
 )]
 impl ExtMuxCascaded {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
@@ -65,9 +65,7 @@ pub struct ExtMuxCascaded {
     unused_variables,
 )]
 impl ExtMuxCascaded {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:191:51
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:189:51
     |
-191 |     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
+189 |     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
     |                                                   ^^^^^^^^^^^^^^^^^^^^^^^
 ...
-294 | pub enum ExtMuxCascadedMuxedA2MuxBIndex {
+292 | pub enum ExtMuxCascadedMuxedA2MuxBIndex {
     | --------------------------------------- similarly named enum `ExtMuxCascadedMuxedA2MuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-191 -     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
-191 +     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxedA2MuxBIndex, CanError> {
+189 -     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
+189 +     pub fn mux_a_multiplexed(&mut self) -> Result<ExtMuxCascadedMuxedA2MuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,109 +18,109 @@ help: you might be missing a type parameter
     |     +++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:195:49
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:193:49
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-195 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+193 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
     |                                                 ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-195 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-195 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
+193 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+193 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:49
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:200:49
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+200 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
     |                                                 ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-202 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-202 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
+200 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+200 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
     |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:229:37
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:227:37
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-229 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+227 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-229 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
-229 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+227 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+227 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
     |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:238:37
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:236:37
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-238 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+236 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-238 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
-238 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+236 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+236 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:229:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:227:5
     |
-151 | /     pub fn set_m0(
-152 | |         &mut self,
-153 | |         value: ExtMuxCascadedMuxedA2MuxBM0,
-154 | |     ) -> Result<(), CanError> {
+149 | /     pub fn set_m0(
+150 | |         &mut self,
+151 | |         value: ExtMuxCascadedMuxedA2MuxBM0,
+152 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-229 |       pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+227 |       pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:238:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:236:5
     |
-163 | /     pub fn set_m1(
-164 | |         &mut self,
-165 | |         value: ExtMuxCascadedMuxedA2MuxBM1,
-166 | |     ) -> Result<(), CanError> {
+161 | /     pub fn set_m1(
+162 | |         &mut self,
+163 | |         value: ExtMuxCascadedMuxedA2MuxBM1,
+164 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-238 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+236 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
 error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:195:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:193:21
     |
-195 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+193 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-195 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-195 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
+193 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+193 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:200:21
     |
-202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+200 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-202 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-202 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
+200 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+200 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
@@ -67,9 +67,7 @@ pub struct ExtMuxIndepMultiplexors {
     unused_variables,
 )]
 impl ExtMuxIndepMultiplexors {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_2_MIN: i8 = 0_i8;
     pub const MUXED_B_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:216:17
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:214:17
     |
-216 |     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+214 |     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-344 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
+342 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
     | ----------------------------------------- similarly named enum `ExtMuxIndepMultiplexorsMuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-216 -     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
-216 +     ) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
+214 -     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+214 +     ) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,172 +18,172 @@ help: you might be missing a type parameter
     |     ++++++++++++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:220:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:218:58
     |
-220 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-359 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+357 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-220 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-220 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+218 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:227:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:225:58
     |
-227 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-426 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+424 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-227 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-227 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+225 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:234:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:232:58
     |
-234 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-533 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+531 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-234 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-234 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+232 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:263:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:261:16
     |
-263 |         value: ExtMuxIndepMultiplexorsMuxAM0,
+261 |         value: ExtMuxIndepMultiplexorsMuxAM0,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-359 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+357 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-263 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-263 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+261 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+261 +         value: ExtMuxIndepMultiplexorsMuxBM0,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:275:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:273:16
     |
-275 |         value: ExtMuxIndepMultiplexorsMuxAM1,
+273 |         value: ExtMuxIndepMultiplexorsMuxAM1,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-426 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+424 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-275 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-275 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+273 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+273 +         value: ExtMuxIndepMultiplexorsMuxBM1,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:287:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:285:16
     |
-287 |         value: ExtMuxIndepMultiplexorsMuxAM2,
+285 |         value: ExtMuxIndepMultiplexorsMuxAM2,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-533 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+531 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-287 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-287 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+285 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+285 +         value: ExtMuxIndepMultiplexorsMuxBM2,
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:261:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:259:5
     |
-162 | /     pub fn set_m0(
-163 | |         &mut self,
-164 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
-165 | |     ) -> Result<(), CanError> {
+160 | /     pub fn set_m0(
+161 | |         &mut self,
+162 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
+163 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-261 | /     pub fn set_m0(
-262 | |         &mut self,
-263 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
-264 | |     ) -> Result<(), CanError> {
+259 | /     pub fn set_m0(
+260 | |         &mut self,
+261 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
+262 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:273:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:271:5
     |
-174 | /     pub fn set_m1(
-175 | |         &mut self,
-176 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
-177 | |     ) -> Result<(), CanError> {
+172 | /     pub fn set_m1(
+173 | |         &mut self,
+174 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
+175 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-273 | /     pub fn set_m1(
-274 | |         &mut self,
-275 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
-276 | |     ) -> Result<(), CanError> {
+271 | /     pub fn set_m1(
+272 | |         &mut self,
+273 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
+274 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:285:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:283:5
     |
-186 | /     pub fn set_m2(
-187 | |         &mut self,
-188 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
-189 | |     ) -> Result<(), CanError> {
+184 | /     pub fn set_m2(
+185 | |         &mut self,
+186 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
+187 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m2`
 ...
-285 | /     pub fn set_m2(
-286 | |         &mut self,
-287 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
-288 | |     ) -> Result<(), CanError> {
+283 | /     pub fn set_m2(
+284 | |         &mut self,
+285 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
+286 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:220:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:218:21
     |
-220 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-220 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-220 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:227:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:225:21
     |
-227 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-227 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-227 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:234:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:232:21
     |
-234 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-234 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-234 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
@@ -67,9 +67,7 @@ pub struct ExtMuxIndepMultiplexors {
     unused_variables,
 )]
 impl ExtMuxIndepMultiplexors {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:216:17
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:214:17
     |
-216 |     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+214 |     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-344 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
+342 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
     | ----------------------------------------- similarly named enum `ExtMuxIndepMultiplexorsMuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-216 -     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
-216 +     ) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
+214 -     ) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+214 +     ) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,172 +18,172 @@ help: you might be missing a type parameter
     |     ++++++++++++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:220:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:218:58
     |
-220 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-359 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+357 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-220 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-220 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+218 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:227:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:225:58
     |
-227 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-426 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+424 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-227 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-227 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+225 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:234:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:232:58
     |
-234 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-533 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+531 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-234 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-234 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+232 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:263:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:261:16
     |
-263 |         value: ExtMuxIndepMultiplexorsMuxAM0,
+261 |         value: ExtMuxIndepMultiplexorsMuxAM0,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-359 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+357 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-263 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-263 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+261 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+261 +         value: ExtMuxIndepMultiplexorsMuxBM0,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:275:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:273:16
     |
-275 |         value: ExtMuxIndepMultiplexorsMuxAM1,
+273 |         value: ExtMuxIndepMultiplexorsMuxAM1,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-426 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+424 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-275 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-275 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+273 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+273 +         value: ExtMuxIndepMultiplexorsMuxBM1,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:287:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:285:16
     |
-287 |         value: ExtMuxIndepMultiplexorsMuxAM2,
+285 |         value: ExtMuxIndepMultiplexorsMuxAM2,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-533 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+531 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-287 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-287 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+285 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+285 +         value: ExtMuxIndepMultiplexorsMuxBM2,
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:261:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:259:5
     |
-162 | /     pub fn set_m0(
-163 | |         &mut self,
-164 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
-165 | |     ) -> Result<(), CanError> {
+160 | /     pub fn set_m0(
+161 | |         &mut self,
+162 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
+163 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-261 | /     pub fn set_m0(
-262 | |         &mut self,
-263 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
-264 | |     ) -> Result<(), CanError> {
+259 | /     pub fn set_m0(
+260 | |         &mut self,
+261 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
+262 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:273:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:271:5
     |
-174 | /     pub fn set_m1(
-175 | |         &mut self,
-176 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
-177 | |     ) -> Result<(), CanError> {
+172 | /     pub fn set_m1(
+173 | |         &mut self,
+174 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
+175 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-273 | /     pub fn set_m1(
-274 | |         &mut self,
-275 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
-276 | |     ) -> Result<(), CanError> {
+271 | /     pub fn set_m1(
+272 | |         &mut self,
+273 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
+274 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:285:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:283:5
     |
-186 | /     pub fn set_m2(
-187 | |         &mut self,
-188 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
-189 | |     ) -> Result<(), CanError> {
+184 | /     pub fn set_m2(
+185 | |         &mut self,
+186 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
+187 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m2`
 ...
-285 | /     pub fn set_m2(
-286 | |         &mut self,
-287 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
-288 | |     ) -> Result<(), CanError> {
+283 | /     pub fn set_m2(
+284 | |         &mut self,
+285 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
+286 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:220:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:218:21
     |
-220 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-220 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-220 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+218 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:227:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:225:21
     |
-227 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-227 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-227 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+225 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:234:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:232:21
     |
-234 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-234 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-234 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+232 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
@@ -65,9 +65,7 @@ pub struct ExtMuxMultipleValues {
     unused_variables,
 )]
 impl ExtMuxMultipleValues {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_2_MIN: i8 = 0_i8;
     pub const MUXED_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
@@ -65,9 +65,7 @@ pub struct ExtMuxMultipleValues {
     unused_variables,
 )]
 impl ExtMuxMultipleValues {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(ExtendedId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_0_3_4_5_MIN: i8 = 0_i8;
     pub const MUXED_0_3_4_5_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_199.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.rs
@@ -114,9 +114,7 @@ pub struct DriverDoorStatus {
     unused_variables,
 )]
 impl DriverDoorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 1;
     /// Constructs a new `DriverDoorStatus` message from values.
     pub fn new(
@@ -262,9 +260,7 @@ pub struct Chime {
     unused_variables,
 )]
 impl Chime {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 5;
     pub const CHIME_TYPE_MIN: u8 = 0_u8;
     pub const CHIME_TYPE_MAX: u8 = 0_u8;
@@ -569,9 +565,9 @@ pub struct BlinkerStatus {
     unused_variables,
 )]
 impl BlinkerStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     /// Constructs a new `BlinkerStatus` message from values.
     pub fn new(
@@ -857,9 +853,7 @@ pub struct SteeringWheelAngle {
     unused_variables,
 )]
 impl SteeringWheelAngle {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
@@ -1002,9 +996,9 @@ pub struct GearShifter {
     unused_variables,
 )]
 impl GearShifter {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
@@ -1200,9 +1194,9 @@ pub struct GasPedalRegenCruise {
     unused_variables,
 )]
 impl GasPedalRegenCruise {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xa000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xa000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GAS_PEDAL_MIN: u8 = 0_u8;
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
@@ -1468,9 +1462,7 @@ pub struct BrakePedal {
     unused_variables,
 )]
 impl BrakePedal {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 2;
     pub const BRAKE_LEVEL_MIN: u8 = 0_u8;
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
@@ -1646,9 +1638,9 @@ pub struct WheelSpeed {
     unused_variables,
 )]
 impl WheelSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x8000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const WHEEL_SPEED_FL_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_FL_MAX: f32 = 70_f32;
@@ -1910,9 +1902,7 @@ pub struct VehicleSpeed {
     unused_variables,
 )]
 impl VehicleSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const VEHICLE_SPEED1_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
@@ -2100,9 +2090,9 @@ pub struct CruiseButtons {
     unused_variables,
 )]
 impl CruiseButtons {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x8000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
@@ -2226,9 +2216,9 @@ pub struct CruiseButtons2 {
     unused_variables,
 )]
 impl CruiseButtons2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x6000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -1,254 +1,311 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1012:30
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1006:30
      |
-1012 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+1006 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
      |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1145 | pub enum GearShifterLeftBlinker {
+1139 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
-1012 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-1012 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+1006 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+1006 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
      |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1028:35
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1022:35
      |
-1028 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+1022 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
      |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1145 | pub enum GearShifterLeftBlinker {
+1139 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
-1028 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-1028 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+1022 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+1022 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
      |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1059:16
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1053:16
      |
-1059 |         value: GearShifterGearShifter,
+1053 |         value: GearShifterGearShifter,
      |                ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1145 | pub enum GearShifterLeftBlinker {
+1139 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
-1059 -         value: GearShifterGearShifter,
-1059 +         value: GearShifterLeftBlinker,
+1053 -         value: GearShifterGearShifter,
+1053 +         value: GearShifterLeftBlinker,
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2110:32
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2100:32
      |
-2110 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2100 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2345 | pub enum CruiseButtons2LkaGapButton {
+2335 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2110 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-2110 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
+2100 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2100 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2126:37
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2116:37
      |
-2126 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2116 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
      |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2345 | pub enum CruiseButtons2LkaGapButton {
+2335 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2126 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2126 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+2116 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2116 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2160:16
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2150:16
      |
-2160 |         value: CruiseButtonsCruiseButtons,
+2150 |         value: CruiseButtonsCruiseButtons,
      |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2345 | pub enum CruiseButtons2LkaGapButton {
+2335 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2160 -         value: CruiseButtonsCruiseButtons,
-2160 +         value: CruiseButtons2LkaGapButton,
+2150 -         value: CruiseButtonsCruiseButtons,
+2150 +         value: CruiseButtons2LkaGapButton,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1031:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1025:18
      |
-1031 |             3 => GearShifterGearShifter::Park,
+1025 |             3 => GearShifterGearShifter::Park,
      |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
      |
 help: an enum with a similar name exists
      |
-1031 -             3 => GearShifterGearShifter::Park,
-1031 +             3 => GearShifterLeftBlinker::Park,
+1025 -             3 => GearShifterGearShifter::Park,
+1025 +             3 => GearShifterLeftBlinker::Park,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1032:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1026:18
      |
-1032 |             0 => GearShifterGearShifter::DriveLow,
+1026 |             0 => GearShifterGearShifter::DriveLow,
      |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
      |
 help: an enum with a similar name exists
      |
-1032 -             0 => GearShifterGearShifter::DriveLow,
-1032 +             0 => GearShifterLeftBlinker::DriveLow,
+1026 -             0 => GearShifterGearShifter::DriveLow,
+1026 +             0 => GearShifterLeftBlinker::DriveLow,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1033:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1027:18
      |
-1033 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
+1027 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
      |
 help: an enum with a similar name exists
      |
-1033 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
-1033 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_phys_val()),
+1027 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
+1027 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_phys_val()),
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2129:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2119:18
      |
-2129 |             6 => CruiseButtonsCruiseButtons::Cancel,
+2119 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2129 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2129 +             6 => CruiseButtons2LkaGapButton::Cancel,
+2119 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2119 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2130:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2120:18
      |
-2130 |             5 => CruiseButtonsCruiseButtons::Main,
+2120 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2130 -             5 => CruiseButtonsCruiseButtons::Main,
-2130 +             5 => CruiseButtons2LkaGapButton::Main,
+2120 -             5 => CruiseButtonsCruiseButtons::Main,
+2120 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2131:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2121:18
      |
-2131 |             3 => CruiseButtonsCruiseButtons::Set,
+2121 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2131 -             3 => CruiseButtonsCruiseButtons::Set,
-2131 +             3 => CruiseButtons2LkaGapButton::Set,
+2121 -             3 => CruiseButtonsCruiseButtons::Set,
+2121 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2132:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2122:18
      |
-2132 |             2 => CruiseButtonsCruiseButtons::Resume,
+2122 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2132 -             2 => CruiseButtonsCruiseButtons::Resume,
-2132 +             2 => CruiseButtons2LkaGapButton::Resume,
+2122 -             2 => CruiseButtonsCruiseButtons::Resume,
+2122 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2133:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2123:18
      |
-2133 |             1 => CruiseButtonsCruiseButtons::None,
+2123 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2133 -             1 => CruiseButtonsCruiseButtons::None,
-2133 +             1 => CruiseButtons2LkaGapButton::None,
+2123 -             1 => CruiseButtonsCruiseButtons::None,
+2123 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2134:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2124:18
      |
-2134 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
+2124 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2134 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
-2134 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_phys_val()),
+2124 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
+2124 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_phys_val()),
      |
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:65:13
-   |
-62 |             DriverDoorStatus::MESSAGE_ID => {
-   |             ---------------------------- matches all the relevant values
-...
-65 |             Chime::MESSAGE_ID => Messages::Chime(Chime::try_from(payload)?),
-   |             ^^^^^^^^^^^^^^^^^ no value can reach this
-   |
-   = note: `-D unreachable-patterns` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:569:9
+    |
+569 |         StandardId::new(0xc000).unwrap(),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BlinkerStatus::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:69:13
-   |
-62 |             DriverDoorStatus::MESSAGE_ID => {
-   |             ---------------------------- matches all the relevant values
-...
-69 |             SteeringWheelAngle::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1000:9
+     |
+1000 |         StandardId::new(0xc000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `GearShifter::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:72:13
-   |
-66 |             BlinkerStatus::MESSAGE_ID => {
-   |             ------------------------- matches all the relevant values
-...
-72 |             GearShifter::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1198:9
+     |
+1198 |         StandardId::new(0xa000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `GasPedalRegenCruise::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:78:13
-   |
-62 |             DriverDoorStatus::MESSAGE_ID => {
-   |             ---------------------------- matches all the relevant values
-...
-78 |             BrakePedal::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1642:9
+     |
+1642 |         StandardId::new(0x8000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `WheelSpeed::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:84:13
-   |
-62 |             DriverDoorStatus::MESSAGE_ID => {
-   |             ---------------------------- matches all the relevant values
-...
-84 |             VehicleSpeed::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2094:9
+     |
+2094 |         StandardId::new(0x8000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CruiseButtons::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199.snap.rs:87:13
-   |
-81 |             WheelSpeed::MESSAGE_ID => {
-   |             ---------------------- matches all the relevant values
-...
-87 |             CruiseButtons::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2220:9
+     |
+2220 |         StandardId::new(0x6000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CruiseButtons2::MESSAGE_ID` failed here
+
+note: erroneous constant encountered
+   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:753:9
+    |
+753 |         Self::MESSAGE_ID
+    |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1094:9
+     |
+1094 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1338:29
+     |
+1338 |                 message_id: GasPedalRegenCruise::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1376:29
+     |
+1376 |                 message_id: GasPedalRegenCruise::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1412:9
+     |
+1412 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1706:29
+     |
+1706 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1750:29
+     |
+1750 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1794:29
+     |
+1794 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1838:29
+     |
+1838 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1877:9
+     |
+1877 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2191:9
+     |
+2191 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2279:29
+     |
+2279 |                 message_id: CruiseButtons2::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2315:9
+     |
+2315 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
@@ -114,9 +114,9 @@ pub struct DriverDoorStatus {
     unused_variables,
 )]
 impl DriverDoorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1fffffff)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x1fffffff).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     /// Constructs a new `DriverDoorStatus` message from values.
     pub fn new(
@@ -262,9 +262,7 @@ pub struct Chime {
     unused_variables,
 )]
 impl Chime {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 5;
     pub const CHIME_TYPE_MIN: u8 = 0_u8;
     pub const CHIME_TYPE_MAX: u8 = 0_u8;
@@ -544,9 +542,9 @@ pub struct BlinkerStatus {
     unused_variables,
 )]
 impl BlinkerStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     /// Constructs a new `BlinkerStatus` message from values.
     pub fn new(
@@ -832,9 +830,7 @@ pub struct SteeringWheelAngle {
     unused_variables,
 )]
 impl SteeringWheelAngle {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
@@ -952,9 +948,9 @@ pub struct GearShifter {
     unused_variables,
 )]
 impl GearShifter {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
@@ -1150,9 +1146,9 @@ pub struct GasPedalRegenCruise {
     unused_variables,
 )]
 impl GasPedalRegenCruise {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xa000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xa000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GAS_PEDAL_MIN: u8 = 0_u8;
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
@@ -1418,9 +1414,7 @@ pub struct BrakePedal {
     unused_variables,
 )]
 impl BrakePedal {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 2;
     pub const BRAKE_LEVEL_MIN: u8 = 0_u8;
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
@@ -1571,9 +1565,9 @@ pub struct WheelSpeed {
     unused_variables,
 )]
 impl WheelSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x8000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const WHEEL_SPEED_FL_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_FL_MAX: f32 = 70_f32;
@@ -1835,9 +1829,7 @@ pub struct VehicleSpeed {
     unused_variables,
 )]
 impl VehicleSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const VEHICLE_SPEED1_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
@@ -2000,9 +1992,9 @@ pub struct CruiseButtons {
     unused_variables,
 )]
 impl CruiseButtons {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x8000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
@@ -2126,9 +2118,9 @@ pub struct CruiseButtons2 {
     unused_variables,
 )]
 impl CruiseButtons2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6000)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x6000).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -1,245 +1,311 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:962:30
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:958:30
      |
- 962 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+ 958 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
      |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1095 | pub enum GearShifterLeftBlinker {
+1091 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 962 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
- 962 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+ 958 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+ 958 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
      |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:978:35
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:974:35
      |
- 978 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 974 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
      |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1095 | pub enum GearShifterLeftBlinker {
+1091 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 978 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 978 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+ 974 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 974 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
      |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1009:16
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1005:16
      |
-1009 |         value: GearShifterGearShifter,
+1005 |         value: GearShifterGearShifter,
      |                ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1095 | pub enum GearShifterLeftBlinker {
+1091 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
-1009 -         value: GearShifterGearShifter,
-1009 +         value: GearShifterLeftBlinker,
+1005 -         value: GearShifterGearShifter,
+1005 +         value: GearShifterLeftBlinker,
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2010:32
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2002:32
      |
-2010 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2002 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2245 | pub enum CruiseButtons2LkaGapButton {
+2237 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2010 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-2010 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
+2002 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2002 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2026:37
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2018:37
      |
-2026 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2018 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
      |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2245 | pub enum CruiseButtons2LkaGapButton {
+2237 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2026 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2026 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+2018 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2018 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2060:16
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2052:16
      |
-2060 |         value: CruiseButtonsCruiseButtons,
+2052 |         value: CruiseButtonsCruiseButtons,
      |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2245 | pub enum CruiseButtons2LkaGapButton {
+2237 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2060 -         value: CruiseButtonsCruiseButtons,
-2060 +         value: CruiseButtons2LkaGapButton,
+2052 -         value: CruiseButtonsCruiseButtons,
+2052 +         value: CruiseButtons2LkaGapButton,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:981:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:977:18
     |
-981 |             3 => GearShifterGearShifter::Park,
+977 |             3 => GearShifterGearShifter::Park,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-981 -             3 => GearShifterGearShifter::Park,
-981 +             3 => GearShifterLeftBlinker::Park,
+977 -             3 => GearShifterGearShifter::Park,
+977 +             3 => GearShifterLeftBlinker::Park,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:982:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:978:18
     |
-982 |             0 => GearShifterGearShifter::DriveLow,
+978 |             0 => GearShifterGearShifter::DriveLow,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-982 -             0 => GearShifterGearShifter::DriveLow,
-982 +             0 => GearShifterLeftBlinker::DriveLow,
+978 -             0 => GearShifterGearShifter::DriveLow,
+978 +             0 => GearShifterLeftBlinker::DriveLow,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:983:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:979:18
     |
-983 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
+979 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-983 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
-983 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_phys_val()),
+979 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_phys_val()),
+979 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_phys_val()),
     |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2029:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2021:18
      |
-2029 |             6 => CruiseButtonsCruiseButtons::Cancel,
+2021 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2029 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2029 +             6 => CruiseButtons2LkaGapButton::Cancel,
+2021 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2021 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2030:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2022:18
      |
-2030 |             5 => CruiseButtonsCruiseButtons::Main,
+2022 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2030 -             5 => CruiseButtonsCruiseButtons::Main,
-2030 +             5 => CruiseButtons2LkaGapButton::Main,
+2022 -             5 => CruiseButtonsCruiseButtons::Main,
+2022 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2031:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2023:18
      |
-2031 |             3 => CruiseButtonsCruiseButtons::Set,
+2023 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2031 -             3 => CruiseButtonsCruiseButtons::Set,
-2031 +             3 => CruiseButtons2LkaGapButton::Set,
+2023 -             3 => CruiseButtonsCruiseButtons::Set,
+2023 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2032:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2024:18
      |
-2032 |             2 => CruiseButtonsCruiseButtons::Resume,
+2024 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2032 -             2 => CruiseButtonsCruiseButtons::Resume,
-2032 +             2 => CruiseButtons2LkaGapButton::Resume,
+2024 -             2 => CruiseButtonsCruiseButtons::Resume,
+2024 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2033:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2025:18
      |
-2033 |             1 => CruiseButtonsCruiseButtons::None,
+2025 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2033 -             1 => CruiseButtonsCruiseButtons::None,
-2033 +             1 => CruiseButtons2LkaGapButton::None,
+2025 -             1 => CruiseButtonsCruiseButtons::None,
+2025 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2034:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2026:18
      |
-2034 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
+2026 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2034 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
-2034 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_phys_val()),
+2026 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_phys_val()),
+2026 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_phys_val()),
      |
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:69:13
-   |
-65 |             Chime::MESSAGE_ID => Messages::Chime(Chime::try_from(payload)?),
-   |             ----------------- matches all the relevant values
-...
-69 |             SteeringWheelAngle::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
-   |
-   = note: `-D unreachable-patterns` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:546:9
+    |
+546 |         StandardId::new(0xc000).unwrap(),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BlinkerStatus::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:72:13
-   |
-66 |             BlinkerStatus::MESSAGE_ID => {
-   |             ------------------------- matches all the relevant values
-...
-72 |             GearShifter::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:952:9
+    |
+952 |         StandardId::new(0xc000).unwrap(),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `GearShifter::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:78:13
-   |
-65 |             Chime::MESSAGE_ID => Messages::Chime(Chime::try_from(payload)?),
-   |             ----------------- matches all the relevant values
-...
-78 |             BrakePedal::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1150:9
+     |
+1150 |         StandardId::new(0xa000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `GasPedalRegenCruise::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:84:13
-   |
-65 |             Chime::MESSAGE_ID => Messages::Chime(Chime::try_from(payload)?),
-   |             ----------------- matches all the relevant values
-...
-84 |             VehicleSpeed::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1569:9
+     |
+1569 |         StandardId::new(0x8000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `WheelSpeed::MESSAGE_ID` failed here
 
-error: unreachable pattern
-  --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:87:13
-   |
-81 |             WheelSpeed::MESSAGE_ID => {
-   |             ---------------------- matches all the relevant values
-...
-87 |             CruiseButtons::MESSAGE_ID => {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1996:9
+     |
+1996 |         StandardId::new(0x8000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CruiseButtons::MESSAGE_ID` failed here
+
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2122:9
+     |
+2122 |         StandardId::new(0x6000).unwrap(),
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CruiseButtons2::MESSAGE_ID` failed here
+
+note: erroneous constant encountered
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:730:9
+    |
+730 |         Self::MESSAGE_ID
+    |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1046:9
+     |
+1046 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1290:29
+     |
+1290 |                 message_id: GasPedalRegenCruise::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1328:29
+     |
+1328 |                 message_id: GasPedalRegenCruise::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1364:9
+     |
+1364 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1633:29
+     |
+1633 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1677:29
+     |
+1677 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1721:29
+     |
+1721 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1765:29
+     |
+1765 |                 message_id: WheelSpeed::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1804:9
+     |
+1804 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2093:9
+     |
+2093 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2181:29
+     |
+2181 |                 message_id: CruiseButtons2::MESSAGE_ID,
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2217:9
+     |
+2217 |         Self::MESSAGE_ID
+     |         ^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
@@ -63,9 +63,7 @@ pub struct MyMsg {
     unused_variables,
 )]
 impl MyMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MY_EXTRA_SIG_WITH_PLUS_MIN: i16 = -128_i16;
     pub const MY_EXTRA_SIG_WITH_PLUS_MAX: i16 = 127_i16;

--- a/tests-snapshots/dbc-cantools/issue_228.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_228.snap.rs
@@ -66,9 +66,7 @@ pub struct SgMsg {
     unused_variables,
 )]
 impl SgMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -265,9 +263,7 @@ pub struct NormalMsg {
     unused_variables,
 )]
 impl NormalMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_63.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_63.snap.rs
@@ -63,9 +63,9 @@ pub struct Aft1psi2 {
     unused_variables,
 )]
 impl Aft1psi2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x18fc8bfe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x18fc8bfe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const HTR_RES_MIN: f32 = 0_f32;
     pub const HTR_RES_MAX: f32 = 6425.5_f32;

--- a/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
@@ -68,9 +68,9 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_MIN: f32 = 4070_f32;
     pub const TEMPERATURE_MAX: f32 = 4100_f32;

--- a/tests-snapshots/dbc-cantools/issue_725.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_725.snap.rs
@@ -66,9 +66,7 @@ pub struct TestMessage {
     unused_variables,
 )]
 impl TestMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL1_MIN: u8 = 0_u8;
     pub const SIGNAL1_MAX: u8 = 250_u8;

--- a/tests-snapshots/dbc-cantools/j1939.snap.rs
+++ b/tests-snapshots/dbc-cantools/j1939.snap.rs
@@ -67,9 +67,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x15340201)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x15340201).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;
@@ -181,9 +181,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x15f01002)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x15f01002).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i8 = 0_i8;
     pub const SIGNAL2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names.snap.rs
@@ -130,9 +130,7 @@ pub struct Ss123456789012345678901234587890 {
     unused_variables,
 )]
 impl Ss123456789012345678901234587890 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x9)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x9).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `SS123456789012345678901234587890` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -200,9 +198,7 @@ pub struct Ss12345678901234567890123450000 {
     unused_variables,
 )]
 impl Ss12345678901234567890123450000 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x8).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `SS1234567890123456789012345_0000` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -270,9 +266,7 @@ pub struct Ss12345678901234567890123450001 {
     unused_variables,
 )]
 impl Ss12345678901234567890123450001 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x7)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x7).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `SS1234567890123456789012345_0001` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -340,9 +334,7 @@ pub struct Ss123456789012345678901234577890 {
     unused_variables,
 )]
 impl Ss123456789012345678901234577890 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x6).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `SS123456789012345678901234577890` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -410,9 +402,7 @@ pub struct Ss123456789012345678901234567890 {
     unused_variables,
 )]
 impl Ss123456789012345678901234567890 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x5).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `SS123456789012345678901234567890` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -480,9 +470,7 @@ pub struct S1234567890123456789012345678901 {
     unused_variables,
 )]
 impl S1234567890123456789012345678901 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SS123456789012345678901234567890_MIN: i8 = 0_i8;
     pub const SS123456789012345678901234567890_MAX: i8 = 0_i8;
@@ -596,9 +584,7 @@ pub struct M123456789012345678901234560000 {
     unused_variables,
 )]
 impl M123456789012345678901234560000 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SSS12345678901234567890123456789_MIN: i8 = 0_i8;
     pub const SSS12345678901234567890123456789_MAX: i8 = 0_i8;
@@ -713,9 +699,7 @@ pub struct M1234567890123456789012345678901 {
     unused_variables,
 )]
 impl M1234567890123456789012345678901 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SS1234567890123456789012345_0000_MIN: i8 = 0_i8;
     pub const SS1234567890123456789012345_0000_MAX: i8 = 0_i8;
@@ -1020,9 +1004,7 @@ pub struct M123456789012345678901234560001 {
     unused_variables,
 )]
 impl M123456789012345678901234560001 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SS1234567890123456789012345_0003_MIN: i8 = 0_i8;
     pub const SS1234567890123456789012345_0003_MAX: i8 = 0_i8;
@@ -1279,9 +1261,7 @@ pub struct Mm123456789012345678901234567890 {
     unused_variables,
 )]
 impl Mm123456789012345678901234567890 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SSS123456789012345678901234_0000_MIN: i8 = 0_i8;
     pub const SSS123456789012345678901234_0000_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
@@ -104,9 +104,9 @@ pub struct MsgLongName5678912345678912 {
     unused_variables,
 )]
 impl MsgLongName5678912345678912 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x55)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x55).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
@@ -314,9 +314,7 @@ pub struct TxTwice {
     unused_variables,
 )]
 impl TxTwice {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x6).unwrap());
     pub const MESSAGE_SIZE: usize = 2;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MIN: i8 = 0_i8;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
@@ -477,9 +475,7 @@ pub struct RxTx1 {
     unused_variables,
 )]
 impl RxTx1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x5).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
@@ -593,9 +589,7 @@ pub struct MsgCaseTest {
     unused_variables,
 )]
 impl MsgCaseTest {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `MSG_CASE_TEST` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -663,9 +657,7 @@ pub struct MsgCaseTest {
     unused_variables,
 )]
 impl MsgCaseTest {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `msg_case_test` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -733,9 +725,7 @@ pub struct MsgWithValueTableSigs {
     unused_variables,
 )]
 impl MsgWithValueTableSigs {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 3;
     pub const SIG_WITH_SHORT_VAL_TABLE_MIN: i8 = 0_i8;
     pub const SIG_WITH_SHORT_VAL_TABLE_MAX: i8 = 0_i8;
@@ -1110,9 +1100,7 @@ pub struct MsgLongName5678912345670000 {
     unused_variables,
 )]
 impl MsgLongName5678912345670000 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
@@ -1275,9 +1263,7 @@ pub struct MsgLongName5678912345670001 {
     unused_variables,
 )]
 impl MsgLongName5678912345670001 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
@@ -10,86 +10,86 @@ error[E0428]: the name `MsgCaseTest` is defined multiple times
    = note: `MsgCaseTest` must be defined only once in the type namespace of this enum
 
 error[E0428]: the name `MsgCaseTest` is defined multiple times
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:653:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:647:1
     |
-583 | pub struct MsgCaseTest {
+579 | pub struct MsgCaseTest {
     | ---------------------- previous definition of the type `MsgCaseTest` here
 ...
-653 | pub struct MsgCaseTest {
+647 | pub struct MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^ `MsgCaseTest` redefined here
     |
     = note: `MsgCaseTest` must be defined only once in the type namespace of this module
 
 error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:652:10
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:646:10
     |
-582 | #[derive(Clone, Copy)]
+578 | #[derive(Clone, Copy)]
     |          ----- first implementation here
 ...
-652 | #[derive(Clone, Copy)]
+646 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:652:17
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:646:17
     |
-582 | #[derive(Clone, Copy)]
+578 | #[derive(Clone, Copy)]
     |                 ---- first implementation here
 ...
-652 | #[derive(Clone, Copy)]
+646 | #[derive(Clone, Copy)]
     |                 ^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `TryFrom<&[u8]>` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:680:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:672:1
     |
-610 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+604 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | -------------------------------------------------- first implementation here
 ...
-680 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+672 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Frame` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:692:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:684:1
     |
-622 | impl embedded_can::Frame for MsgCaseTest {
+616 | impl embedded_can::Frame for MsgCaseTest {
     | ---------------------------------------- first implementation here
 ...
-692 | impl embedded_can::Frame for MsgCaseTest {
+684 | impl embedded_can::Frame for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0592]: duplicate definitions with name `MESSAGE_ID`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_ID`
 ...
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     -------------------------------------- other definition for `MESSAGE_ID`
 
 error[E0592]: duplicate definitions with name `MESSAGE_SIZE`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:599:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:593:5
     |
-599 |     pub const MESSAGE_SIZE: usize = 8;
+593 |     pub const MESSAGE_SIZE: usize = 8;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_SIZE`
 ...
-669 |     pub const MESSAGE_SIZE: usize = 8;
+661 |     pub const MESSAGE_SIZE: usize = 8;
     |     ----------------------------- other definition for `MESSAGE_SIZE`
 
 error[E0592]: duplicate definitions with name `new`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:601:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:595:5
     |
-601 |     pub fn new() -> Result<Self, CanError> {
+595 |     pub fn new() -> Result<Self, CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `new`
 ...
-671 |     pub fn new() -> Result<Self, CanError> {
+663 |     pub fn new() -> Result<Self, CanError> {
     |     -------------------------------------- other definition for `new`
 
 error[E0592]: duplicate definitions with name `raw`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:606:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:600:5
     |
-606 |     pub fn raw(&self) -> &[u8; 8] {
+600 |     pub fn raw(&self) -> &[u8; 8] {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `raw`
 ...
-676 |     pub fn raw(&self) -> &[u8; 8] {
+668 |     pub fn raw(&self) -> &[u8; 8] {
     |     ----------------------------- other definition for `raw`
 
 error[E0034]: multiple applicable items in scope
@@ -99,14 +99,14 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
@@ -116,80 +116,80 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:624:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:618:31
     |
-624 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+618 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:639:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:633:15
     |
-639 |         Self::MESSAGE_ID
+633 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:694:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:31
     |
-694 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+686 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:709:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:701:15
     |
-709 |         Self::MESSAGE_ID
+701 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
@@ -104,9 +104,9 @@ pub struct MsgLongName5678912345678912 {
     unused_variables,
 )]
 impl MsgLongName5678912345678912 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x55)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x55).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i32 = 0_i32;
     pub const RX_TWICE_SHORT_MAX: i32 = 0_i32;
@@ -314,9 +314,7 @@ pub struct TxTwice {
     unused_variables,
 )]
 impl TxTwice {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x6).unwrap());
     pub const MESSAGE_SIZE: usize = 2;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MIN: i8 = 0_i8;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
@@ -477,9 +475,7 @@ pub struct RxTx1 {
     unused_variables,
 )]
 impl RxTx1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x5).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
@@ -593,9 +589,7 @@ pub struct MsgCaseTest {
     unused_variables,
 )]
 impl MsgCaseTest {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `MSG_CASE_TEST` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -663,9 +657,7 @@ pub struct MsgCaseTest {
     unused_variables,
 )]
 impl MsgCaseTest {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     /// Constructs a new `msg_case_test` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -733,9 +725,7 @@ pub struct MsgWithValueTableSigs {
     unused_variables,
 )]
 impl MsgWithValueTableSigs {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 3;
     pub const SIG_WITH_SHORT_VAL_TABLE_MIN: i8 = 0_i8;
     pub const SIG_WITH_SHORT_VAL_TABLE_MAX: i8 = 0_i8;
@@ -1110,9 +1100,7 @@ pub struct MsgLongName5678912345670000 {
     unused_variables,
 )]
 impl MsgLongName5678912345670000 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
@@ -1275,9 +1263,7 @@ pub struct MsgLongName5678912345670001 {
     unused_variables,
 )]
 impl MsgLongName5678912345670001 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
@@ -10,86 +10,86 @@ error[E0428]: the name `MsgCaseTest` is defined multiple times
    = note: `MsgCaseTest` must be defined only once in the type namespace of this enum
 
 error[E0428]: the name `MsgCaseTest` is defined multiple times
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:653:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:647:1
     |
-583 | pub struct MsgCaseTest {
+579 | pub struct MsgCaseTest {
     | ---------------------- previous definition of the type `MsgCaseTest` here
 ...
-653 | pub struct MsgCaseTest {
+647 | pub struct MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^ `MsgCaseTest` redefined here
     |
     = note: `MsgCaseTest` must be defined only once in the type namespace of this module
 
 error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:652:10
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:646:10
     |
-582 | #[derive(Clone, Copy)]
+578 | #[derive(Clone, Copy)]
     |          ----- first implementation here
 ...
-652 | #[derive(Clone, Copy)]
+646 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:652:17
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:646:17
     |
-582 | #[derive(Clone, Copy)]
+578 | #[derive(Clone, Copy)]
     |                 ---- first implementation here
 ...
-652 | #[derive(Clone, Copy)]
+646 | #[derive(Clone, Copy)]
     |                 ^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `TryFrom<&[u8]>` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:680:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:672:1
     |
-610 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+604 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | -------------------------------------------------- first implementation here
 ...
-680 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+672 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Frame` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:692:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:684:1
     |
-622 | impl embedded_can::Frame for MsgCaseTest {
+616 | impl embedded_can::Frame for MsgCaseTest {
     | ---------------------------------------- first implementation here
 ...
-692 | impl embedded_can::Frame for MsgCaseTest {
+684 | impl embedded_can::Frame for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0592]: duplicate definitions with name `MESSAGE_ID`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_ID`
 ...
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     -------------------------------------- other definition for `MESSAGE_ID`
 
 error[E0592]: duplicate definitions with name `MESSAGE_SIZE`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:599:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:593:5
     |
-599 |     pub const MESSAGE_SIZE: usize = 8;
+593 |     pub const MESSAGE_SIZE: usize = 8;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_SIZE`
 ...
-669 |     pub const MESSAGE_SIZE: usize = 8;
+661 |     pub const MESSAGE_SIZE: usize = 8;
     |     ----------------------------- other definition for `MESSAGE_SIZE`
 
 error[E0592]: duplicate definitions with name `new`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:601:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:595:5
     |
-601 |     pub fn new() -> Result<Self, CanError> {
+595 |     pub fn new() -> Result<Self, CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `new`
 ...
-671 |     pub fn new() -> Result<Self, CanError> {
+663 |     pub fn new() -> Result<Self, CanError> {
     |     -------------------------------------- other definition for `new`
 
 error[E0592]: duplicate definitions with name `raw`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:606:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:600:5
     |
-606 |     pub fn raw(&self) -> &[u8; 8] {
+600 |     pub fn raw(&self) -> &[u8; 8] {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `raw`
 ...
-676 |     pub fn raw(&self) -> &[u8; 8] {
+668 |     pub fn raw(&self) -> &[u8; 8] {
     |     ----------------------------- other definition for `raw`
 
 error[E0034]: multiple applicable items in scope
@@ -99,14 +99,14 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
@@ -116,80 +116,80 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:624:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:618:31
     |
-624 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+618 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:639:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:633:15
     |
-639 |         Self::MESSAGE_ID
+633 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:694:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:31
     |
-694 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+686 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:709:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:701:15
     |
-709 |         Self::MESSAGE_ID
+701 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:596:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:592:5
     |
-596 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+592 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:666:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:660:5
     |
-666 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+660 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
+++ b/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
@@ -64,9 +64,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 0;
     /// Constructs a new `Message1` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
@@ -66,9 +66,7 @@ pub struct MsgNowShort {
     unused_variables,
 )]
 impl MsgNowShort {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_NOW_SHORT_MIN: u8 = 0_u8;
     pub const SIG_NOW_SHORT_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
@@ -68,9 +68,7 @@ pub struct MsgWillBeShortened345678912 {
     unused_variables,
 )]
 impl MsgWillBeShortened345678912 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MIN: u8 = 0_u8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/motohawk.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk.snap.rs
@@ -68,9 +68,9 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
@@ -68,9 +68,9 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1f0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x1f0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
@@ -68,9 +68,9 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
@@ -68,9 +68,9 @@ pub struct ExampleMessage {
     unused_variables,
 )]
 impl ExampleMessage {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f0).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;

--- a/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
+++ b/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
@@ -64,9 +64,9 @@ pub struct BatteryVt {
     unused_variables,
 )]
 impl BatteryVt {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x401)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x401).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 6;
     pub const MODULE_TEMP_35_MIN: u16 = 0_u16;
     pub const MODULE_TEMP_35_MAX: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
@@ -64,9 +64,7 @@ pub struct Bar {
     unused_variables,
 )]
 impl Bar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;

--- a/tests-snapshots/dbc-cantools/multiplex.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex.snap.rs
@@ -63,9 +63,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123456)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123456).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
@@ -74,9 +74,9 @@ pub struct Shared {
     unused_variables,
 )]
 impl Shared {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc02fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc02fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
@@ -359,9 +359,9 @@ pub struct Normal {
     unused_variables,
 )]
 impl Normal {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc01fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc01fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
@@ -644,9 +644,9 @@ pub struct Extended {
     unused_variables,
 )]
 impl Extended {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc00fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc00fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S8_MIN: i8 = 0_i8;
     pub const S8_MAX: i8 = 0_i8;
@@ -1210,9 +1210,9 @@ pub struct ExtendedTypes {
     unused_variables,
 )]
 impl ExtendedTypes {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc03fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc03fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S9_MIN: i32 = -1.34_i32;
     pub const S9_MAX: i32 = 1235_i32;

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
@@ -74,9 +74,9 @@ pub struct Shared {
     unused_variables,
 )]
 impl Shared {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc02fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc02fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
@@ -359,9 +359,9 @@ pub struct Normal {
     unused_variables,
 )]
 impl Normal {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc01fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc01fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
@@ -644,9 +644,9 @@ pub struct Extended {
     unused_variables,
 )]
 impl Extended {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc00fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc00fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S7_MIN: i32 = 0_i32;
     pub const S7_MAX: i32 = 0_i32;
@@ -1281,9 +1281,9 @@ pub struct ExtendedTypes {
     unused_variables,
 )]
 impl ExtendedTypes {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xc03fefe)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xc03fefe).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const S9_MIN: i32 = -1.34_i32;
     pub const S9_MAX: i32 = 1235_i32;

--- a/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
@@ -69,9 +69,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123456)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123456).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
@@ -716,9 +716,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123457)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123457).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
@@ -1332,9 +1332,9 @@ pub struct Message3 {
     unused_variables,
 )]
 impl Message3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123458)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123458).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
@@ -69,9 +69,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123456)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123456).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
@@ -716,9 +716,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123457)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123457).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
@@ -1332,9 +1332,9 @@ pub struct Message3 {
     unused_variables,
 )]
 impl Message3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123458)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123458).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
@@ -63,9 +63,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x123456)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x123456).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/no_sender.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_sender.snap.rs
@@ -65,9 +65,9 @@ pub struct Foo {
     unused_variables,
 )]
 impl Foo {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1d8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1d8).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL_WITHOUT_SENDER_MIN: i8 = 0_i8;
     pub const SIGNAL_WITHOUT_SENDER_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/no_signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_signals.snap.rs
@@ -67,9 +67,9 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x400)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x400).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 5;
     /// Constructs a new `Message1` message from values.
     pub fn new() -> Result<Self, CanError> {
@@ -138,9 +138,9 @@ pub struct Message2 {
     unused_variables,
 )]
 impl Message2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x401)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x401).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 0;
     /// Constructs a new `Message2` message from values.
     pub fn new() -> Result<Self, CanError> {

--- a/tests-snapshots/dbc-cantools/open_actuator.snap.rs
+++ b/tests-snapshots/dbc-cantools/open_actuator.snap.rs
@@ -84,9 +84,9 @@ pub struct ControlCmd {
     unused_variables,
 )]
 impl ControlCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xfa)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xfa).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 7;
     pub const CRC8_CMD1_MIN: u8 = 0_u8;
     pub const CRC8_CMD1_MAX: u8 = 255_u8;
@@ -531,9 +531,9 @@ pub struct LimitsCmd {
     unused_variables,
 )]
 impl LimitsCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xfb)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xfb).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 6;
     pub const CRC8_CMD2_MIN: u8 = 0_u8;
     pub const CRC8_CMD2_MAX: u8 = 255_u8;
@@ -771,9 +771,9 @@ pub struct ControlStatus {
     unused_variables,
 )]
 impl ControlStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xfc)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xfc).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const CRC8_STAT1_MIN: u8 = 0_u8;
     pub const CRC8_STAT1_MAX: u8 = 255_u8;
@@ -1025,9 +1025,9 @@ pub struct SystemStatus {
     unused_variables,
 )]
 impl SystemStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xfd)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xfd).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRC8_STAT2_MIN: u8 = 0_u8;
     pub const CRC8_STAT2_MAX: u8 = 255_u8;
@@ -1232,9 +1232,9 @@ pub struct TorqueSensorData {
     unused_variables,
 )]
 impl TorqueSensorData {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x71)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x71).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRC8_DATA1_MIN: u8 = 0_u8;
     pub const CRC8_DATA1_MAX: u8 = 255_u8;

--- a/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
+++ b/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
@@ -76,9 +76,7 @@ pub struct Msg0 {
     unused_variables,
 )]
 impl Msg0 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const A_MIN: u16 = 0_u16;
     pub const A_MAX: u16 = 32767_u16;
@@ -299,9 +297,7 @@ pub struct Msg1 {
     unused_variables,
 )]
 impl Msg1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const F_MIN: u16 = 0_u16;
     pub const F_MAX: u16 = 32767_u16;
@@ -522,9 +518,7 @@ pub struct Msg2 {
     unused_variables,
 )]
 impl Msg2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const I_MIN: u8 = 0_u8;
     pub const I_MAX: u8 = 15_u8;
@@ -716,9 +710,7 @@ pub struct Msg3 {
     unused_variables,
 )]
 impl Msg3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const L_MIN: u64 = 0_u64;
     pub const L_MAX: u64 = 18446744073709551615_u64;
@@ -828,9 +820,7 @@ pub struct Msg4 {
     unused_variables,
 )]
 impl Msg4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x5).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const M_MIN: u64 = 0_u64;
     pub const M_MAX: u64 = 18446744073709551615_u64;

--- a/tests-snapshots/dbc-cantools/sig_groups.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups.snap.rs
@@ -73,9 +73,7 @@ pub struct Test {
     unused_variables,
 )]
 impl Test {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
@@ -186,9 +184,7 @@ pub struct SgMsgM {
     unused_variables,
 )]
 impl SgMsgM {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -433,9 +429,7 @@ pub struct SgMsg {
     unused_variables,
 )]
 impl SgMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -632,9 +626,7 @@ pub struct NormalMsg {
     unused_variables,
 )]
 impl NormalMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
@@ -73,9 +73,7 @@ pub struct Test {
     unused_variables,
 )]
 impl Test {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
@@ -186,9 +184,7 @@ pub struct SgMsgM {
     unused_variables,
 )]
 impl SgMsgM {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -433,9 +429,7 @@ pub struct SgMsg {
     unused_variables,
 )]
 impl SgMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -632,9 +626,7 @@ pub struct NormalMsg {
     unused_variables,
 )]
 impl NormalMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
@@ -73,9 +73,7 @@ pub struct Test {
     unused_variables,
 )]
 impl Test {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
@@ -186,9 +184,7 @@ pub struct SgMsgM {
     unused_variables,
 )]
 impl SgMsgM {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -433,9 +429,7 @@ pub struct SgMsg {
     unused_variables,
 )]
 impl SgMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
@@ -632,9 +626,7 @@ pub struct NormalMsg {
     unused_variables,
 )]
 impl NormalMsg {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/signed.snap.rs
+++ b/tests-snapshots/dbc-cantools/signed.snap.rs
@@ -107,9 +107,7 @@ pub struct Message378910 {
     unused_variables,
 )]
 impl Message378910 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xa)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0xa).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S3BIG_MIN: i8 = 0_i8;
     pub const S3BIG_MAX: i8 = 0_i8;
@@ -530,9 +528,7 @@ pub struct Message63big1 {
     unused_variables,
 )]
 impl Message63big1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x9)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x9).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
@@ -643,9 +639,7 @@ pub struct Message631 {
     unused_variables,
 )]
 impl Message631 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x8).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
@@ -756,9 +750,7 @@ pub struct Message63big {
     unused_variables,
 )]
 impl Message63big {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x7)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x7).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
@@ -869,9 +861,7 @@ pub struct Message63 {
     unused_variables,
 )]
 impl Message63 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x6)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x6).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
@@ -982,9 +972,7 @@ pub struct Message32big {
     unused_variables,
 )]
 impl Message32big {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x5)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x5).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S32BIG_MIN: i32 = 0_i32;
     pub const S32BIG_MAX: i32 = 0_i32;
@@ -1095,9 +1083,7 @@ pub struct Message33big {
     unused_variables,
 )]
 impl Message33big {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x4).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S33BIG_MIN: i64 = 0_i64;
     pub const S33BIG_MAX: i64 = 0_i64;
@@ -1208,9 +1194,7 @@ pub struct Message64big {
     unused_variables,
 )]
 impl Message64big {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x3)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x3).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S64BIG_MIN: i64 = 0_i64;
     pub const S64BIG_MAX: i64 = 0_i64;
@@ -1321,9 +1305,7 @@ pub struct Message64 {
     unused_variables,
 )]
 impl Message64 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S64_MIN: i64 = -9223372036854780000_i64;
     pub const S64_MAX: i64 = 9223372036854780000_i64;
@@ -1434,9 +1416,7 @@ pub struct Message33 {
     unused_variables,
 )]
 impl Message33 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S33_MIN: i64 = -4294967296_i64;
     pub const S33_MAX: i64 = 4294967295_i64;
@@ -1547,9 +1527,7 @@ pub struct Message32 {
     unused_variables,
 )]
 impl Message32 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const S32_MIN: i32 = 0_i32;
     pub const S32_MAX: i32 = 0_i32;

--- a/tests-snapshots/dbc-cantools/signed.snap.stderr
+++ b/tests-snapshots/dbc-cantools/signed.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1328:30
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1310:30
      |
-1328 |     pub const S64_MIN: i64 = -9223372036854780000_i64;
+1310 |     pub const S64_MIN: i64 = -9223372036854780000_i64;
      |                              ^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `-9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
@@ -9,27 +9,27 @@ error: literal out of range for `i64`
      = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1329:30
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1311:30
      |
-1329 |     pub const S64_MAX: i64 = 9223372036854780000_i64;
+1311 |     pub const S64_MAX: i64 = 9223372036854780000_i64;
      |                              ^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
      = help: consider using the type `u64` instead
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1371:20
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1353:20
      |
-1371 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
+1353 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
      |                    ^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `-9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
      = help: consider using the type `i128` instead
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1371:48
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1353:48
      |
-1371 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
+1353 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
      |                                                ^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -84,9 +84,9 @@ pub struct DriverHeartbeat {
     unused_variables,
 )]
 impl DriverHeartbeat {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x64)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x64).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
@@ -242,9 +242,9 @@ pub struct IoDebug {
     unused_variables,
 )]
 impl IoDebug {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f4).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
@@ -527,9 +527,9 @@ pub struct MotorCmd {
     unused_variables,
 )]
 impl MotorCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x65)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x65).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -693,9 +693,9 @@ pub struct MotorStatus {
     unused_variables,
 )]
 impl MotorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x190)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x190).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
@@ -850,9 +850,9 @@ pub struct SensorSonars {
     unused_variables,
 )]
 impl SensorSonars {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc8).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_NO_FILT_REAR_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -84,9 +84,9 @@ pub struct DriverHeartbeat {
     unused_variables,
 )]
 impl DriverHeartbeat {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x64)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x64).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
@@ -242,9 +242,9 @@ pub struct IoDebug {
     unused_variables,
 )]
 impl IoDebug {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f4).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
@@ -527,9 +527,9 @@ pub struct MotorCmd {
     unused_variables,
 )]
 impl MotorCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x65)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x65).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -693,9 +693,9 @@ pub struct MotorStatus {
     unused_variables,
 )]
 impl MotorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x190)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x190).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
@@ -850,9 +850,9 @@ pub struct SensorSonars {
     unused_variables,
 )]
 impl SensorSonars {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc8).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -84,9 +84,9 @@ pub struct DriverHeartbeat {
     unused_variables,
 )]
 impl DriverHeartbeat {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x64)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x64).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
@@ -242,9 +242,9 @@ pub struct IoDebug {
     unused_variables,
 )]
 impl IoDebug {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f4).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
@@ -527,9 +527,9 @@ pub struct MotorCmd {
     unused_variables,
 )]
 impl MotorCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x65)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x65).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -693,9 +693,9 @@ pub struct MotorStatus {
     unused_variables,
 )]
 impl MotorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x190)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x190).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
@@ -850,9 +850,9 @@ pub struct SensorSonars {
     unused_variables,
 )]
 impl SensorSonars {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc8).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -84,9 +84,9 @@ pub struct DriverHeartbeat {
     unused_variables,
 )]
 impl DriverHeartbeat {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x64)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x64).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
@@ -242,9 +242,9 @@ pub struct IoDebug {
     unused_variables,
 )]
 impl IoDebug {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1f4)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x1f4).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 4;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
@@ -527,9 +527,9 @@ pub struct MotorCmd {
     unused_variables,
 )]
 impl MotorCmd {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x65)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x65).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 1;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -693,9 +693,9 @@ pub struct MotorStatus {
     unused_variables,
 )]
 impl MotorStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x190)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x190).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
@@ -850,9 +850,9 @@ pub struct SensorSonars {
     unused_variables,
 )]
 impl SensorSonars {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0xc8)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0xc8).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
@@ -68,9 +68,9 @@ pub struct SomeFrame {
     unused_variables,
 )]
 impl SomeFrame {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x100)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x100).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_DIFFERENT_SIG_MIN: i8 = 0_i8;
     pub const SOME_DIFFERENT_SIG_MAX: i8 = 0_i8;
@@ -181,9 +181,9 @@ pub struct SomeExtFrame {
     unused_variables,
 )]
 impl SomeExtFrame {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x1c2a2a2a)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x1c2a2a2a).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_SIG_MIN: i8 = 0_i8;
     pub const SOME_SIG_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
@@ -65,9 +65,9 @@ pub struct MuxedFrame {
     unused_variables,
 )]
 impl MuxedFrame {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x100)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(
+        StandardId::new(0x100).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const UNMULTIPLEXED_SIG_MIN: i8 = 0_i8;
     pub const UNMULTIPLEXED_SIG_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -67,9 +67,7 @@ pub struct Foo {
     unused_variables,
 )]
 impl Foo {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 200;
     pub const FOO_MIN: f32 = 229.53_f32;
@@ -188,9 +186,7 @@ pub struct Bar {
     unused_variables,
 )]
 impl Bar {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x2)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x2).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;

--- a/tests-snapshots/dbc-cantools/val_table.snap.rs
+++ b/tests-snapshots/dbc-cantools/val_table.snap.rs
@@ -63,9 +63,7 @@ pub struct Message1 {
     unused_variables,
 )]
 impl Message1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
+++ b/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
@@ -71,9 +71,9 @@ pub struct TestMessage1 {
     unused_variables,
 )]
 impl TestMessage1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xff0100)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xff0100).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const SIGNAL1_MIN: u8 = 0_u8;
     pub const SIGNAL1_MAX: u8 = 0_u8;
@@ -265,9 +265,9 @@ pub struct TestMessage2 {
     unused_variables,
 )]
 impl TestMessage2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0xff0200)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0xff0200).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 10;
     pub const SIGNAL4_MIN: u16 = 0_u16;
     pub const SIGNAL4_MAX: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/vehicle.snap.rs
+++ b/tests-snapshots/dbc-cantools/vehicle.snap.rs
@@ -1163,9 +1163,9 @@ pub struct RtSbInsVelBodyAxes {
     unused_variables,
 )]
 impl RtSbInsVelBodyAxes {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9588322)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9588322).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_SIDEWAYS_2D_MIN: f32 = -838_f32;
     pub const INS_VEL_SIDEWAYS_2D_MAX: f32 = 838_f32;
@@ -1464,9 +1464,9 @@ pub struct RtDl1mk3Speed {
     unused_variables,
 )]
 impl RtDl1mk3Speed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a7c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a7c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SPEED_MIN: f32 = -20000_f32;
     pub const SPEED_MAX: f32 = 20000_f32;
@@ -1667,9 +1667,9 @@ pub struct RtDl1mk3GpsTime {
     unused_variables,
 )]
 impl RtDl1mk3GpsTime {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_WEEK_MIN: u16 = 0_u16;
     pub const GPS_WEEK_MAX: u16 = 65535_u16;
@@ -1948,9 +1948,9 @@ pub struct RtDl1mk3GpsPosLlh2 {
     unused_variables,
 )]
 impl RtDl1mk3GpsPosLlh2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
@@ -2119,9 +2119,9 @@ pub struct RtDl1mk3GpsPosLlh1 {
     unused_variables,
 )]
 impl RtDl1mk3GpsPosLlh1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const GPS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
@@ -2504,9 +2504,9 @@ pub struct RtDl1mk3GpsSpeed {
     unused_variables,
 )]
 impl RtDl1mk3GpsSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_SPEED_3D_MIN: f32 = 0_f32;
     pub const GPS_SPEED_3D_MAX: f32 = 1675_f32;
@@ -2795,9 +2795,9 @@ pub struct RtIrTempTemp7 {
     unused_variables,
 )]
 impl RtIrTempTemp7 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7325)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7325).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_7_MAX: f32 = 0_f32;
@@ -2914,9 +2914,9 @@ pub struct RtIrTempTempRr2 {
     unused_variables,
 )]
 impl RtIrTempTempRr2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9627425)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9627425).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_32_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_32_MAX: f32 = 0_f32;
@@ -3185,9 +3185,9 @@ pub struct RtIrTempTempRl2 {
     unused_variables,
 )]
 impl RtIrTempTempRl2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9627225)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9627225).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_24_MAX: f32 = 0_f32;
@@ -3456,9 +3456,9 @@ pub struct RtIrTempTempFr2 {
     unused_variables,
 )]
 impl RtIrTempTempFr2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9627025)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9627025).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_16_MAX: f32 = 0_f32;
@@ -3727,9 +3727,9 @@ pub struct RtIrTempTempFl2 {
     unused_variables,
 )]
 impl RtIrTempTempFl2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9626e25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9626e25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_8_MAX: f32 = 0_f32;
@@ -3998,9 +3998,9 @@ pub struct RtIrTempTempRr1 {
     unused_variables,
 )]
 impl RtIrTempTempRr1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9627325)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9627325).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_28_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_28_MAX: f32 = 0_f32;
@@ -4269,9 +4269,9 @@ pub struct RtIrTempTempRl1 {
     unused_variables,
 )]
 impl RtIrTempTempRl1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9627125)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9627125).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_20_MAX: f32 = 0_f32;
@@ -4540,9 +4540,9 @@ pub struct RtIrTempTempFr1 {
     unused_variables,
 )]
 impl RtIrTempTempFr1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9626f25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9626f25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_12_MAX: f32 = 0_f32;
@@ -4811,9 +4811,9 @@ pub struct RtIrTempTempFl1 {
     unused_variables,
 )]
 impl RtIrTempTempFl1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9626d25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9626d25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_4_MAX: f32 = 0_f32;
@@ -5082,9 +5082,9 @@ pub struct RtIrTempTemp32 {
     unused_variables,
 )]
 impl RtIrTempTemp32 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8c25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8c25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_32_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_32_MAX: f32 = 0_f32;
@@ -5201,9 +5201,9 @@ pub struct RtIrTempTemp31 {
     unused_variables,
 )]
 impl RtIrTempTemp31 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8b25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8b25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_31_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_31_MAX: f32 = 0_f32;
@@ -5320,9 +5320,9 @@ pub struct RtIrTempTemp30 {
     unused_variables,
 )]
 impl RtIrTempTemp30 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8a25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8a25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_30_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_30_MAX: f32 = 0_f32;
@@ -5439,9 +5439,9 @@ pub struct RtIrTempTemp29 {
     unused_variables,
 )]
 impl RtIrTempTemp29 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8925)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8925).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_29_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_29_MAX: f32 = 0_f32;
@@ -5558,9 +5558,9 @@ pub struct RtIrTempTemp28 {
     unused_variables,
 )]
 impl RtIrTempTemp28 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8825)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8825).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_28_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_28_MAX: f32 = 0_f32;
@@ -5677,9 +5677,9 @@ pub struct RtIrTempTemp27 {
     unused_variables,
 )]
 impl RtIrTempTemp27 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8725)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8725).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_27_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_27_MAX: f32 = 0_f32;
@@ -5796,9 +5796,9 @@ pub struct RtIrTempTemp26 {
     unused_variables,
 )]
 impl RtIrTempTemp26 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8625)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8625).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_26_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_26_MAX: f32 = 0_f32;
@@ -5915,9 +5915,9 @@ pub struct RtIrTempTemp25 {
     unused_variables,
 )]
 impl RtIrTempTemp25 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8525)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8525).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_25_MAX: f32 = 0_f32;
@@ -6034,9 +6034,9 @@ pub struct RtIrTempTemp24 {
     unused_variables,
 )]
 impl RtIrTempTemp24 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8425)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8425).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_24_MAX: f32 = 0_f32;
@@ -6153,9 +6153,9 @@ pub struct RtIrTempTemp22 {
     unused_variables,
 )]
 impl RtIrTempTemp22 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8225)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8225).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_22_MAX: f32 = 0_f32;
@@ -6272,9 +6272,9 @@ pub struct RtIrTempTemp23 {
     unused_variables,
 )]
 impl RtIrTempTemp23 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8325)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8325).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_23_MAX: f32 = 0_f32;
@@ -6391,9 +6391,9 @@ pub struct RtIrTempTemp21 {
     unused_variables,
 )]
 impl RtIrTempTemp21 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8125)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8125).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_21_MAX: f32 = 0_f32;
@@ -6510,9 +6510,9 @@ pub struct RtIrTempTemp20 {
     unused_variables,
 )]
 impl RtIrTempTemp20 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8025)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8025).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_20_MAX: f32 = 0_f32;
@@ -6629,9 +6629,9 @@ pub struct RtIrTempTemp19 {
     unused_variables,
 )]
 impl RtIrTempTemp19 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7f25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7f25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_19_MAX: f32 = 0_f32;
@@ -6748,9 +6748,9 @@ pub struct RtIrTempTemp18 {
     unused_variables,
 )]
 impl RtIrTempTemp18 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7e25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7e25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_18_MAX: f32 = 0_f32;
@@ -6867,9 +6867,9 @@ pub struct RtIrTempTemp16 {
     unused_variables,
 )]
 impl RtIrTempTemp16 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7c25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7c25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_16_MAX: f32 = 0_f32;
@@ -6986,9 +6986,9 @@ pub struct RtIrTempTemp15 {
     unused_variables,
 )]
 impl RtIrTempTemp15 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7b25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7b25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_15_MAX: f32 = 0_f32;
@@ -7105,9 +7105,9 @@ pub struct RtIrTempTemp14 {
     unused_variables,
 )]
 impl RtIrTempTemp14 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7a25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7a25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_14_MAX: f32 = 0_f32;
@@ -7224,9 +7224,9 @@ pub struct RtIrTempTemp13 {
     unused_variables,
 )]
 impl RtIrTempTemp13 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7925)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7925).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_13_MAX: f32 = 0_f32;
@@ -7343,9 +7343,9 @@ pub struct RtIrTempTemp12 {
     unused_variables,
 )]
 impl RtIrTempTemp12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7825)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7825).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_12_MAX: f32 = 0_f32;
@@ -7462,9 +7462,9 @@ pub struct RtIrTempTemp11 {
     unused_variables,
 )]
 impl RtIrTempTemp11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7725)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7725).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_11_MAX: f32 = 0_f32;
@@ -7581,9 +7581,9 @@ pub struct RtIrTempTemp10 {
     unused_variables,
 )]
 impl RtIrTempTemp10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7625)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7625).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_10_MAX: f32 = 0_f32;
@@ -7700,9 +7700,9 @@ pub struct RtIrTempTemp8 {
     unused_variables,
 )]
 impl RtIrTempTemp8 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7425)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7425).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_8_MAX: f32 = 0_f32;
@@ -7819,9 +7819,9 @@ pub struct RtIrTempTemp9 {
     unused_variables,
 )]
 impl RtIrTempTemp9 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7525)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7525).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_9_MAX: f32 = 0_f32;
@@ -7938,9 +7938,9 @@ pub struct RtIrTempTemp17 {
     unused_variables,
 )]
 impl RtIrTempTemp17 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7d25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7d25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_17_MAX: f32 = 0_f32;
@@ -8057,9 +8057,9 @@ pub struct RtIrTempTemp6 {
     unused_variables,
 )]
 impl RtIrTempTemp6 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7225)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7225).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_6_MAX: f32 = 0_f32;
@@ -8176,9 +8176,9 @@ pub struct RtIrTempTemp5 {
     unused_variables,
 )]
 impl RtIrTempTemp5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7125)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7125).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_5_MAX: f32 = 0_f32;
@@ -8295,9 +8295,9 @@ pub struct RtIrTempTemp4 {
     unused_variables,
 )]
 impl RtIrTempTemp4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7025)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7025).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_4_MAX: f32 = 0_f32;
@@ -8414,9 +8414,9 @@ pub struct RtIrTempTemp3 {
     unused_variables,
 )]
 impl RtIrTempTemp3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6f25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6f25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_3_MAX: f32 = 0_f32;
@@ -8533,9 +8533,9 @@ pub struct RtIrTempTemp2 {
     unused_variables,
 )]
 impl RtIrTempTemp2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6e25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6e25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_2_MAX: f32 = 0_f32;
@@ -8652,9 +8652,9 @@ pub struct RtIrTempTemp1 {
     unused_variables,
 )]
 impl RtIrTempTemp1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6d25)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6d25).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_1_MAX: f32 = 0_f32;
@@ -8771,9 +8771,9 @@ pub struct RtSbTrigFinalCondition {
     unused_variables,
 )]
 impl RtSbTrigFinalCondition {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9577322)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9577322).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const FINAL_SPEED_MIN: f32 = 0_f32;
     pub const FINAL_SPEED_MAX: f32 = 1675_f32;
@@ -8927,9 +8927,9 @@ pub struct RtSbTrigInitialCondition {
     unused_variables,
 )]
 impl RtSbTrigInitialCondition {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9577222)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9577222).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const MFDD_END_THRESHOLD_MIN: u8 = 0_u8;
     pub const MFDD_END_THRESHOLD_MAX: u8 = 100_u8;
@@ -9260,9 +9260,9 @@ pub struct RtSbTrigDirectDist {
     unused_variables,
 )]
 impl RtSbTrigDirectDist {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9577122)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9577122).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const PATH_DISTANCE_2D_MIN: f32 = 0_f32;
     pub const PATH_DISTANCE_2D_MAX: f32 = 4294967_f32;
@@ -9428,9 +9428,9 @@ pub struct RtSbTrigForwardDist {
     unused_variables,
 )]
 impl RtSbTrigForwardDist {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9577022)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9577022).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const DEVIATION_DISTANCE_MIN: f32 = -2147483.648_f32;
     pub const DEVIATION_DISTANCE_MAX: f32 = 2147483.647_f32;
@@ -9603,9 +9603,9 @@ pub struct RtSbTrigPathDist {
     unused_variables,
 )]
 impl RtSbTrigPathDist {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9576f22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9576f22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const PATH_DISTANCE_3D_MIN: f32 = 0_f32;
     pub const PATH_DISTANCE_3D_MAX: f32 = 4294967_f32;
@@ -9722,9 +9722,9 @@ pub struct RtSbTrigAccel {
     unused_variables,
 )]
 impl RtSbTrigAccel {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9576e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9576e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const TRIGGERED_TIME_MIN: f32 = 0_f32;
     pub const TRIGGERED_TIME_MAX: f32 = 167772_f32;
@@ -10061,9 +10061,9 @@ pub struct RtDl1mk3MeasureTime12 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_12_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_12_MAX: u32 = 0_u32;
@@ -10172,9 +10172,9 @@ pub struct RtDl1mk3MeasureTime11 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_11_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_11_MAX: u32 = 0_u32;
@@ -10283,9 +10283,9 @@ pub struct RtDl1mk3MeasureTime10 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_10_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_10_MAX: u32 = 0_u32;
@@ -10394,9 +10394,9 @@ pub struct RtDl1mk3MeasureTime9 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime9 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_9_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_9_MAX: u32 = 0_u32;
@@ -10505,9 +10505,9 @@ pub struct RtDl1mk3MeasureTime8 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime8 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_8_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_8_MAX: u32 = 0_u32;
@@ -10616,9 +10616,9 @@ pub struct RtDl1mk3MeasureTime7 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime7 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_7_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_7_MAX: u32 = 0_u32;
@@ -10727,9 +10727,9 @@ pub struct RtDl1mk3MeasureTime6 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime6 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_6_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_6_MAX: u32 = 0_u32;
@@ -10838,9 +10838,9 @@ pub struct RtDl1mk3MeasureTime5 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_5_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_5_MAX: u32 = 0_u32;
@@ -10949,9 +10949,9 @@ pub struct RtDl1mk3MeasureTime4 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9607024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9607024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_4_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_4_MAX: u32 = 0_u32;
@@ -11060,9 +11060,9 @@ pub struct RtDl1mk3MeasureTime3 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9606f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9606f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_3_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_3_MAX: u32 = 0_u32;
@@ -11171,9 +11171,9 @@ pub struct RtDl1mk3MeasureTime2 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9606e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9606e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_2_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_2_MAX: u32 = 0_u32;
@@ -11282,9 +11282,9 @@ pub struct RtDl1mk3MeasureTime1 {
     unused_variables,
 )]
 impl RtDl1mk3MeasureTime1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9606d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9606d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_1_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_1_MAX: u32 = 0_u32;
@@ -11393,9 +11393,9 @@ pub struct RtDl1mk3Rpm {
     unused_variables,
 )]
 impl RtDl1mk3Rpm {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95f7824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95f7824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const RPM_MIN: u16 = 0_u16;
     pub const RPM_MAX: u16 = 0_u16;
@@ -11504,9 +11504,9 @@ pub struct RtDl1mk3Freq4 {
     unused_variables,
 )]
 impl RtDl1mk3Freq4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95f7724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95f7724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_4_MIN: f32 = 0_f32;
     pub const FREQUENCY_4_MAX: f32 = 0_f32;
@@ -11621,9 +11621,9 @@ pub struct RtDl1mk3Freq3 {
     unused_variables,
 )]
 impl RtDl1mk3Freq3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95f7624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95f7624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_3_MIN: f32 = 0_f32;
     pub const FREQUENCY_3_MAX: f32 = 0_f32;
@@ -11738,9 +11738,9 @@ pub struct RtDl1mk3Freq2 {
     unused_variables,
 )]
 impl RtDl1mk3Freq2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95f7524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95f7524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_2_MIN: f32 = 0_f32;
     pub const FREQUENCY_2_MAX: f32 = 0_f32;
@@ -11855,9 +11855,9 @@ pub struct RtDl1mk3Misc3 {
     unused_variables,
 )]
 impl RtDl1mk3Misc3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9616f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9616f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_3_MIN: f32 = 0_f32;
     pub const MISC_3_MAX: f32 = 0_f32;
@@ -11972,9 +11972,9 @@ pub struct RtDl1mk3Misc2 {
     unused_variables,
 )]
 impl RtDl1mk3Misc2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9616e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9616e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_2_MIN: f32 = 0_f32;
     pub const MISC_2_MAX: f32 = 0_f32;
@@ -12089,9 +12089,9 @@ pub struct RtDl1mk3Misc1 {
     unused_variables,
 )]
 impl RtDl1mk3Misc1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9616d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9616d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_1_MIN: f32 = 0_f32;
     pub const MISC_1_MAX: f32 = 0_f32;
@@ -12206,9 +12206,9 @@ pub struct RtDl1mk3Aux31 {
     unused_variables,
 )]
 impl RtDl1mk3Aux31 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8b24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8b24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_31_MIN: f32 = 0_f32;
     pub const AUX_31_MAX: f32 = 0_f32;
@@ -12323,9 +12323,9 @@ pub struct RtDl1mk3Aux30 {
     unused_variables,
 )]
 impl RtDl1mk3Aux30 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8a24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8a24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_30_MIN: f32 = 0_f32;
     pub const AUX_30_MAX: f32 = 0_f32;
@@ -12440,9 +12440,9 @@ pub struct RtDl1mk3Aux29 {
     unused_variables,
 )]
 impl RtDl1mk3Aux29 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8924)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8924).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_29_MIN: f32 = 0_f32;
     pub const AUX_29_MAX: f32 = 0_f32;
@@ -12557,9 +12557,9 @@ pub struct RtDl1mk3Aux28 {
     unused_variables,
 )]
 impl RtDl1mk3Aux28 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_28_MIN: f32 = 0_f32;
     pub const AUX_28_MAX: f32 = 0_f32;
@@ -12674,9 +12674,9 @@ pub struct RtDl1mk3Aux27 {
     unused_variables,
 )]
 impl RtDl1mk3Aux27 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_27_MIN: f32 = 0_f32;
     pub const AUX_27_MAX: f32 = 0_f32;
@@ -12791,9 +12791,9 @@ pub struct RtDl1mk3Aux26 {
     unused_variables,
 )]
 impl RtDl1mk3Aux26 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_26_MIN: f32 = 0_f32;
     pub const AUX_26_MAX: f32 = 0_f32;
@@ -12908,9 +12908,9 @@ pub struct RtDl1mk3Aux25 {
     unused_variables,
 )]
 impl RtDl1mk3Aux25 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_25_MIN: f32 = 0_f32;
     pub const AUX_25_MAX: f32 = 0_f32;
@@ -13025,9 +13025,9 @@ pub struct RtDl1mk3Aux24 {
     unused_variables,
 )]
 impl RtDl1mk3Aux24 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_24_MIN: f32 = 0_f32;
     pub const AUX_24_MAX: f32 = 0_f32;
@@ -13142,9 +13142,9 @@ pub struct RtDl1mk3Aux23 {
     unused_variables,
 )]
 impl RtDl1mk3Aux23 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_23_MIN: f32 = 0_f32;
     pub const AUX_23_MAX: f32 = 0_f32;
@@ -13259,9 +13259,9 @@ pub struct RtDl1mk3Aux22 {
     unused_variables,
 )]
 impl RtDl1mk3Aux22 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_22_MIN: u32 = 0_u32;
     pub const AUX_22_MAX: u32 = 0_u32;
@@ -13379,9 +13379,9 @@ pub struct RtDl1mk3Aux21 {
     unused_variables,
 )]
 impl RtDl1mk3Aux21 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_21_MIN: f32 = 0_f32;
     pub const AUX_21_MAX: f32 = 0_f32;
@@ -13496,9 +13496,9 @@ pub struct RtDl1mk3Aux20 {
     unused_variables,
 )]
 impl RtDl1mk3Aux20 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e8024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e8024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_20_MIN: f32 = 0_f32;
     pub const AUX_20_MAX: f32 = 0_f32;
@@ -13613,9 +13613,9 @@ pub struct RtDl1mk3Aux19 {
     unused_variables,
 )]
 impl RtDl1mk3Aux19 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_19_MIN: f32 = 0_f32;
     pub const AUX_19_MAX: f32 = 0_f32;
@@ -13730,9 +13730,9 @@ pub struct RtDl1mk3Aux18 {
     unused_variables,
 )]
 impl RtDl1mk3Aux18 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_18_MIN: f32 = 0_f32;
     pub const AUX_18_MAX: f32 = 0_f32;
@@ -13847,9 +13847,9 @@ pub struct RtDl1mk3Aux17 {
     unused_variables,
 )]
 impl RtDl1mk3Aux17 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_17_MIN: f32 = 0_f32;
     pub const AUX_17_MAX: f32 = 0_f32;
@@ -13964,9 +13964,9 @@ pub struct RtDl1mk3Aux16 {
     unused_variables,
 )]
 impl RtDl1mk3Aux16 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_16_MIN: f32 = 0_f32;
     pub const AUX_16_MAX: f32 = 0_f32;
@@ -14081,9 +14081,9 @@ pub struct RtDl1mk3Aux15 {
     unused_variables,
 )]
 impl RtDl1mk3Aux15 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7b24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7b24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_15_MIN: f32 = 0_f32;
     pub const AUX_15_MAX: f32 = 0_f32;
@@ -14198,9 +14198,9 @@ pub struct RtDl1mk3Aux14 {
     unused_variables,
 )]
 impl RtDl1mk3Aux14 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7a24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7a24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_14_MIN: f32 = 0_f32;
     pub const AUX_14_MAX: f32 = 0_f32;
@@ -14315,9 +14315,9 @@ pub struct RtDl1mk3Aux13 {
     unused_variables,
 )]
 impl RtDl1mk3Aux13 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7924)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7924).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_13_MIN: f32 = 0_f32;
     pub const AUX_13_MAX: f32 = 0_f32;
@@ -14432,9 +14432,9 @@ pub struct RtDl1mk3Aux12 {
     unused_variables,
 )]
 impl RtDl1mk3Aux12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_12_MIN: f32 = 0_f32;
     pub const AUX_12_MAX: f32 = 0_f32;
@@ -14549,9 +14549,9 @@ pub struct RtDl1mk3Aux11 {
     unused_variables,
 )]
 impl RtDl1mk3Aux11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_11_MIN: f32 = 0_f32;
     pub const AUX_11_MAX: f32 = 0_f32;
@@ -14666,9 +14666,9 @@ pub struct RtDl1mk3Aux9 {
     unused_variables,
 )]
 impl RtDl1mk3Aux9 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_9_MIN: f32 = 0_f32;
     pub const AUX_9_MAX: f32 = 0_f32;
@@ -14783,9 +14783,9 @@ pub struct RtDl1mk3Aux10 {
     unused_variables,
 )]
 impl RtDl1mk3Aux10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_10_MIN: f32 = 0_f32;
     pub const AUX_10_MAX: f32 = 0_f32;
@@ -14900,9 +14900,9 @@ pub struct RtDl1mk3Aux8 {
     unused_variables,
 )]
 impl RtDl1mk3Aux8 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_8_MIN: f32 = 0_f32;
     pub const AUX_8_MAX: f32 = 0_f32;
@@ -15017,9 +15017,9 @@ pub struct RtDl1mk3Aux7 {
     unused_variables,
 )]
 impl RtDl1mk3Aux7 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_7_MIN: f32 = 0_f32;
     pub const AUX_7_MAX: f32 = 0_f32;
@@ -15134,9 +15134,9 @@ pub struct RtDl1mk3Aux6 {
     unused_variables,
 )]
 impl RtDl1mk3Aux6 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_6_MIN: f32 = 0_f32;
     pub const AUX_6_MAX: f32 = 0_f32;
@@ -15251,9 +15251,9 @@ pub struct RtDl1mk3Aux5 {
     unused_variables,
 )]
 impl RtDl1mk3Aux5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_5_MIN: f32 = 0_f32;
     pub const AUX_5_MAX: f32 = 0_f32;
@@ -15368,9 +15368,9 @@ pub struct RtDl1mk3Aux4 {
     unused_variables,
 )]
 impl RtDl1mk3Aux4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e7024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e7024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_4_MIN: f32 = 0_f32;
     pub const AUX_4_MAX: f32 = 0_f32;
@@ -15485,9 +15485,9 @@ pub struct RtDl1mk3Aux3 {
     unused_variables,
 )]
 impl RtDl1mk3Aux3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e6f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e6f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_3_MIN: f32 = 0_f32;
     pub const AUX_3_MAX: f32 = 0_f32;
@@ -15602,9 +15602,9 @@ pub struct RtDl1mk3Aux2 {
     unused_variables,
 )]
 impl RtDl1mk3Aux2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e6e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e6e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_2_MIN: f32 = 0_f32;
     pub const AUX_2_MAX: f32 = 0_f32;
@@ -15719,9 +15719,9 @@ pub struct RtDl1mk3Aux1 {
     unused_variables,
 )]
 impl RtDl1mk3Aux1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95e6d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95e6d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_1_MIN: f32 = 0_f32;
     pub const AUX_1_MAX: f32 = 0_f32;
@@ -15836,9 +15836,9 @@ pub struct RtDl1mk3Pressure5 {
     unused_variables,
 )]
 impl RtDl1mk3Pressure5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95a7124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95a7124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_5_MIN: f32 = 0_f32;
     pub const PRESSURE_5_MAX: f32 = 0_f32;
@@ -15953,9 +15953,9 @@ pub struct RtDl1mk3Pressure4 {
     unused_variables,
 )]
 impl RtDl1mk3Pressure4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95a7024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95a7024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_4_MIN: f32 = 0_f32;
     pub const PRESSURE_4_MAX: f32 = 0_f32;
@@ -16070,9 +16070,9 @@ pub struct RtDl1mk3Pressure3 {
     unused_variables,
 )]
 impl RtDl1mk3Pressure3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95a6f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95a6f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_3_MIN: f32 = 0_f32;
     pub const PRESSURE_3_MAX: f32 = 0_f32;
@@ -16187,9 +16187,9 @@ pub struct RtDl1mk3Pressure2 {
     unused_variables,
 )]
 impl RtDl1mk3Pressure2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95a6e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95a6e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_2_MIN: f32 = 0_f32;
     pub const PRESSURE_2_MAX: f32 = 0_f32;
@@ -16304,9 +16304,9 @@ pub struct RtDl1mk3Pressure1 {
     unused_variables,
 )]
 impl RtDl1mk3Pressure1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95a6d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95a6d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_1_MIN: f32 = 0_f32;
     pub const PRESSURE_1_MAX: f32 = 0_f32;
@@ -16421,9 +16421,9 @@ pub struct RtDl1mk3Angle3 {
     unused_variables,
 )]
 impl RtDl1mk3Angle3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95c6f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95c6f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_3_MIN: f32 = 0_f32;
     pub const ANGLE_3_MAX: f32 = 0_f32;
@@ -16540,9 +16540,9 @@ pub struct RtDl1mk3Angle2 {
     unused_variables,
 )]
 impl RtDl1mk3Angle2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95c6e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95c6e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_2_MIN: f32 = 0_f32;
     pub const ANGLE_2_MAX: f32 = 0_f32;
@@ -16659,9 +16659,9 @@ pub struct RtDl1mk3Angle1 {
     unused_variables,
 )]
 impl RtDl1mk3Angle1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95c6d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95c6d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_1_MIN: f32 = 0_f32;
     pub const ANGLE_1_MAX: f32 = 0_f32;
@@ -16778,9 +16778,9 @@ pub struct RtDl1mk3Temp25 {
     unused_variables,
 )]
 impl RtDl1mk3Temp25 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const TEMPERATURE_25_MAX: f32 = 0_f32;
@@ -16897,9 +16897,9 @@ pub struct RtDl1mk3Temp24 {
     unused_variables,
 )]
 impl RtDl1mk3Temp24 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const TEMPERATURE_24_MAX: f32 = 0_f32;
@@ -17016,9 +17016,9 @@ pub struct RtDl1mk3Temp23 {
     unused_variables,
 )]
 impl RtDl1mk3Temp23 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const TEMPERATURE_23_MAX: f32 = 0_f32;
@@ -17135,9 +17135,9 @@ pub struct RtDl1mk3Temp22 {
     unused_variables,
 )]
 impl RtDl1mk3Temp22 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const TEMPERATURE_22_MAX: f32 = 0_f32;
@@ -17254,9 +17254,9 @@ pub struct RtDl1mk3Temp21 {
     unused_variables,
 )]
 impl RtDl1mk3Temp21 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const TEMPERATURE_21_MAX: f32 = 0_f32;
@@ -17373,9 +17373,9 @@ pub struct RtDl1mk3Temp20 {
     unused_variables,
 )]
 impl RtDl1mk3Temp20 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b8024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b8024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const TEMPERATURE_20_MAX: f32 = 0_f32;
@@ -17492,9 +17492,9 @@ pub struct RtDl1mk3Temp19 {
     unused_variables,
 )]
 impl RtDl1mk3Temp19 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const TEMPERATURE_19_MAX: f32 = 0_f32;
@@ -17611,9 +17611,9 @@ pub struct RtDl1mk3Temp18 {
     unused_variables,
 )]
 impl RtDl1mk3Temp18 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const TEMPERATURE_18_MAX: f32 = 0_f32;
@@ -17730,9 +17730,9 @@ pub struct RtDl1mk3Temp17 {
     unused_variables,
 )]
 impl RtDl1mk3Temp17 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const TEMPERATURE_17_MAX: f32 = 0_f32;
@@ -17849,9 +17849,9 @@ pub struct RtDl1mk3Temp16 {
     unused_variables,
 )]
 impl RtDl1mk3Temp16 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const TEMPERATURE_16_MAX: f32 = 0_f32;
@@ -17968,9 +17968,9 @@ pub struct RtDl1mk3Temp15 {
     unused_variables,
 )]
 impl RtDl1mk3Temp15 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7b24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7b24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const TEMPERATURE_15_MAX: f32 = 0_f32;
@@ -18087,9 +18087,9 @@ pub struct RtDl1mk3Temp14 {
     unused_variables,
 )]
 impl RtDl1mk3Temp14 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7a24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7a24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const TEMPERATURE_14_MAX: f32 = 0_f32;
@@ -18206,9 +18206,9 @@ pub struct RtDl1mk3Temp13 {
     unused_variables,
 )]
 impl RtDl1mk3Temp13 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7924)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7924).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const TEMPERATURE_13_MAX: f32 = 0_f32;
@@ -18325,9 +18325,9 @@ pub struct RtDl1mk3Temp12 {
     unused_variables,
 )]
 impl RtDl1mk3Temp12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const TEMPERATURE_12_MAX: f32 = 0_f32;
@@ -18444,9 +18444,9 @@ pub struct RtDl1mk3Temp11 {
     unused_variables,
 )]
 impl RtDl1mk3Temp11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const TEMPERATURE_11_MAX: f32 = 0_f32;
@@ -18563,9 +18563,9 @@ pub struct RtDl1mk3Temp10 {
     unused_variables,
 )]
 impl RtDl1mk3Temp10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const TEMPERATURE_10_MAX: f32 = 0_f32;
@@ -18682,9 +18682,9 @@ pub struct RtDl1mk3Temp9 {
     unused_variables,
 )]
 impl RtDl1mk3Temp9 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const TEMPERATURE_9_MAX: f32 = 0_f32;
@@ -18801,9 +18801,9 @@ pub struct RtDl1mk3Temp8 {
     unused_variables,
 )]
 impl RtDl1mk3Temp8 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const TEMPERATURE_8_MAX: f32 = 0_f32;
@@ -18920,9 +18920,9 @@ pub struct RtDl1mk3Temp7 {
     unused_variables,
 )]
 impl RtDl1mk3Temp7 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const TEMPERATURE_7_MAX: f32 = 0_f32;
@@ -19039,9 +19039,9 @@ pub struct RtDl1mk3Temp6 {
     unused_variables,
 )]
 impl RtDl1mk3Temp6 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const TEMPERATURE_6_MAX: f32 = 0_f32;
@@ -19158,9 +19158,9 @@ pub struct RtDl1mk3Temp5 {
     unused_variables,
 )]
 impl RtDl1mk3Temp5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const TEMPERATURE_5_MAX: f32 = 0_f32;
@@ -19277,9 +19277,9 @@ pub struct RtDl1mk3Temp4 {
     unused_variables,
 )]
 impl RtDl1mk3Temp4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b7024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b7024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const TEMPERATURE_4_MAX: f32 = 0_f32;
@@ -19396,9 +19396,9 @@ pub struct RtDl1mk3Temp3 {
     unused_variables,
 )]
 impl RtDl1mk3Temp3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const TEMPERATURE_3_MAX: f32 = 0_f32;
@@ -19515,9 +19515,9 @@ pub struct RtDl1mk3Temp2 {
     unused_variables,
 )]
 impl RtDl1mk3Temp2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const TEMPERATURE_2_MAX: f32 = 0_f32;
@@ -19634,9 +19634,9 @@ pub struct RtDl1mk3Temp1 {
     unused_variables,
 )]
 impl RtDl1mk3Temp1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x95b6d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x95b6d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const TEMPERATURE_1_MAX: f32 = 0_f32;
@@ -19753,9 +19753,9 @@ pub struct RtDl1mk3Analog32 {
     unused_variables,
 )]
 impl RtDl1mk3Analog32 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8b24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8b24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_32_MIN: f32 = 0_f32;
     pub const ANALOG_32_MAX: f32 = 0_f32;
@@ -19870,9 +19870,9 @@ pub struct RtDl1mk3Analog31 {
     unused_variables,
 )]
 impl RtDl1mk3Analog31 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8a24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8a24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_31_MIN: f32 = 0_f32;
     pub const ANALOG_31_MAX: f32 = 0_f32;
@@ -19987,9 +19987,9 @@ pub struct RtDl1mk3Analog30 {
     unused_variables,
 )]
 impl RtDl1mk3Analog30 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8924)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8924).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_30_MIN: f32 = 0_f32;
     pub const ANALOG_30_MAX: f32 = 0_f32;
@@ -20104,9 +20104,9 @@ pub struct RtDl1mk3Analog29 {
     unused_variables,
 )]
 impl RtDl1mk3Analog29 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8824)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8824).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_29_MIN: f32 = 0_f32;
     pub const ANALOG_29_MAX: f32 = 0_f32;
@@ -20221,9 +20221,9 @@ pub struct RtDl1mk3Analog28 {
     unused_variables,
 )]
 impl RtDl1mk3Analog28 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_28_MIN: f32 = 0_f32;
     pub const ANALOG_28_MAX: f32 = 0_f32;
@@ -20338,9 +20338,9 @@ pub struct RtDl1mk3Analog27 {
     unused_variables,
 )]
 impl RtDl1mk3Analog27 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_27_MIN: f32 = 0_f32;
     pub const ANALOG_27_MAX: f32 = 0_f32;
@@ -20455,9 +20455,9 @@ pub struct RtDl1mk3Analog26 {
     unused_variables,
 )]
 impl RtDl1mk3Analog26 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_26_MIN: f32 = 0_f32;
     pub const ANALOG_26_MAX: f32 = 0_f32;
@@ -20572,9 +20572,9 @@ pub struct RtDl1mk3Analog25 {
     unused_variables,
 )]
 impl RtDl1mk3Analog25 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_25_MIN: f32 = 0_f32;
     pub const ANALOG_25_MAX: f32 = 0_f32;
@@ -20689,9 +20689,9 @@ pub struct RtDl1mk3Analog15 {
     unused_variables,
 )]
 impl RtDl1mk3Analog15 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7a24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7a24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_15_MIN: f32 = 0_f32;
     pub const ANALOG_15_MAX: f32 = 0_f32;
@@ -20806,9 +20806,9 @@ pub struct RtDl1mk3Analog14 {
     unused_variables,
 )]
 impl RtDl1mk3Analog14 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7924)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7924).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_14_MIN: f32 = 0_f32;
     pub const ANALOG_14_MAX: f32 = 0_f32;
@@ -20923,9 +20923,9 @@ pub struct RtDl1mk3Analog17 {
     unused_variables,
 )]
 impl RtDl1mk3Analog17 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_17_MIN: f32 = 0_f32;
     pub const ANALOG_17_MAX: f32 = 0_f32;
@@ -21040,9 +21040,9 @@ pub struct RtDl1mk3Analog24 {
     unused_variables,
 )]
 impl RtDl1mk3Analog24 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_24_MIN: f32 = 0_f32;
     pub const ANALOG_24_MAX: f32 = 0_f32;
@@ -21157,9 +21157,9 @@ pub struct RtDl1mk3Analog23 {
     unused_variables,
 )]
 impl RtDl1mk3Analog23 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_23_MIN: f32 = 0_f32;
     pub const ANALOG_23_MAX: f32 = 0_f32;
@@ -21274,9 +21274,9 @@ pub struct RtDl1mk3Analog22 {
     unused_variables,
 )]
 impl RtDl1mk3Analog22 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_22_MIN: f32 = 0_f32;
     pub const ANALOG_22_MAX: f32 = 0_f32;
@@ -21391,9 +21391,9 @@ pub struct RtDl1mk3Analog21 {
     unused_variables,
 )]
 impl RtDl1mk3Analog21 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c8024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c8024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_21_MIN: f32 = 0_f32;
     pub const ANALOG_21_MAX: f32 = 0_f32;
@@ -21508,9 +21508,9 @@ pub struct RtDl1mk3Analog20 {
     unused_variables,
 )]
 impl RtDl1mk3Analog20 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_20_MIN: f32 = 0_f32;
     pub const ANALOG_20_MAX: f32 = 0_f32;
@@ -21625,9 +21625,9 @@ pub struct RtDl1mk3Analog19 {
     unused_variables,
 )]
 impl RtDl1mk3Analog19 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_19_MIN: f32 = 0_f32;
     pub const ANALOG_19_MAX: f32 = 0_f32;
@@ -21742,9 +21742,9 @@ pub struct RtDl1mk3Analog16 {
     unused_variables,
 )]
 impl RtDl1mk3Analog16 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7b24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7b24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_16_MIN: f32 = 0_f32;
     pub const ANALOG_16_MAX: f32 = 0_f32;
@@ -21859,9 +21859,9 @@ pub struct RtDl1mk3Analog18 {
     unused_variables,
 )]
 impl RtDl1mk3Analog18 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_18_MIN: f32 = 0_f32;
     pub const ANALOG_18_MAX: f32 = 0_f32;
@@ -21976,9 +21976,9 @@ pub struct RtDl1mk3Analog12 {
     unused_variables,
 )]
 impl RtDl1mk3Analog12 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7724)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7724).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_12_MIN: f32 = 0_f32;
     pub const ANALOG_12_MAX: f32 = 0_f32;
@@ -22093,9 +22093,9 @@ pub struct RtDl1mk3Analog11 {
     unused_variables,
 )]
 impl RtDl1mk3Analog11 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7624)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7624).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_11_MIN: f32 = 0_f32;
     pub const ANALOG_11_MAX: f32 = 0_f32;
@@ -22210,9 +22210,9 @@ pub struct RtDl1mk3Analog10 {
     unused_variables,
 )]
 impl RtDl1mk3Analog10 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7524)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7524).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_10_MIN: f32 = 0_f32;
     pub const ANALOG_10_MAX: f32 = 0_f32;
@@ -22327,9 +22327,9 @@ pub struct RtDl1mk3Analog9 {
     unused_variables,
 )]
 impl RtDl1mk3Analog9 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7424)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7424).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_9_MIN: f32 = 0_f32;
     pub const ANALOG_9_MAX: f32 = 0_f32;
@@ -22444,9 +22444,9 @@ pub struct RtDl1mk3Analog8 {
     unused_variables,
 )]
 impl RtDl1mk3Analog8 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7324)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7324).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_8_MIN: f32 = 0_f32;
     pub const ANALOG_8_MAX: f32 = 0_f32;
@@ -22561,9 +22561,9 @@ pub struct RtDl1mk3Analog7 {
     unused_variables,
 )]
 impl RtDl1mk3Analog7 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7224)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7224).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_7_MIN: f32 = 0_f32;
     pub const ANALOG_7_MAX: f32 = 0_f32;
@@ -22678,9 +22678,9 @@ pub struct RtDl1mk3Analog6 {
     unused_variables,
 )]
 impl RtDl1mk3Analog6 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7124)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7124).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_6_MIN: f32 = 0_f32;
     pub const ANALOG_6_MAX: f32 = 0_f32;
@@ -22795,9 +22795,9 @@ pub struct RtDl1mk3Analog5 {
     unused_variables,
 )]
 impl RtDl1mk3Analog5 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c7024)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c7024).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_5_MIN: f32 = 0_f32;
     pub const ANALOG_5_MAX: f32 = 0_f32;
@@ -22912,9 +22912,9 @@ pub struct RtDl1mk3Analog4 {
     unused_variables,
 )]
 impl RtDl1mk3Analog4 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c6f24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c6f24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_4_MIN: f32 = 0_f32;
     pub const ANALOG_4_MAX: f32 = 0_f32;
@@ -23029,9 +23029,9 @@ pub struct RtDl1mk3Analog3 {
     unused_variables,
 )]
 impl RtDl1mk3Analog3 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c6e24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c6e24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_3_MIN: f32 = 0_f32;
     pub const ANALOG_3_MAX: f32 = 0_f32;
@@ -23146,9 +23146,9 @@ pub struct RtDl1mk3Analog2 {
     unused_variables,
 )]
 impl RtDl1mk3Analog2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c6d24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c6d24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_2_MIN: f32 = 0_f32;
     pub const ANALOG_2_MAX: f32 = 0_f32;
@@ -23263,9 +23263,9 @@ pub struct RtDl1mk3Analog1 {
     unused_variables,
 )]
 impl RtDl1mk3Analog1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94c6c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94c6c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_1_MIN: f32 = 0_f32;
     pub const ANALOG_1_MAX: f32 = 0_f32;
@@ -23380,9 +23380,9 @@ pub struct RtDl1mk3Accel {
     unused_variables,
 )]
 impl RtDl1mk3Accel {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a6c24)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a6c24).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
@@ -23768,9 +23768,9 @@ pub struct RtSbInsVpt4VelNed2 {
     unused_variables,
 )]
 impl RtSbInsVpt4VelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9599e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9599e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_4_SLIP_MAX: f32 = 180_f32;
@@ -23995,9 +23995,9 @@ pub struct RtSbInsVpt4VelNed1 {
     unused_variables,
 )]
 impl RtSbInsVpt4VelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9599d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9599d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_4_VEL_NED_E_MAX: f32 = 838_f32;
@@ -24170,9 +24170,9 @@ pub struct RtSbInsVpt4Offset {
     unused_variables,
 )]
 impl RtSbInsVpt4Offset {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9599c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9599c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_4_OFFSET_Z_MAX: f32 = 32.767_f32;
@@ -24397,9 +24397,9 @@ pub struct RtSbInsVpt3VelNed2 {
     unused_variables,
 )]
 impl RtSbInsVpt3VelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9598e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9598e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_3_SLIP_MAX: f32 = 180_f32;
@@ -24624,9 +24624,9 @@ pub struct RtSbInsVpt3VelNed1 {
     unused_variables,
 )]
 impl RtSbInsVpt3VelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9598d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9598d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_3_VEL_NED_E_MAX: f32 = 838_f32;
@@ -24799,9 +24799,9 @@ pub struct RtSbInsVpt3Offset {
     unused_variables,
 )]
 impl RtSbInsVpt3Offset {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9598c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9598c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_3_OFFSET_Z_MAX: f32 = 32.767_f32;
@@ -25026,9 +25026,9 @@ pub struct RtSbInsVpt2VelNed2 {
     unused_variables,
 )]
 impl RtSbInsVpt2VelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9597e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9597e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_2_SLIP_MAX: f32 = 180_f32;
@@ -25253,9 +25253,9 @@ pub struct RtSbInsVpt2VelNed1 {
     unused_variables,
 )]
 impl RtSbInsVpt2VelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9597d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9597d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_2_VEL_NED_E_MAX: f32 = 838_f32;
@@ -25428,9 +25428,9 @@ pub struct RtSbInsVpt2Offset {
     unused_variables,
 )]
 impl RtSbInsVpt2Offset {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9597c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9597c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_2_OFFSET_Z_MAX: f32 = 32.767_f32;
@@ -25655,9 +25655,9 @@ pub struct RtSbInsVpt1VelNed2 {
     unused_variables,
 )]
 impl RtSbInsVpt1VelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9596e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9596e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_1_SLIP_MAX: f32 = 180_f32;
@@ -25882,9 +25882,9 @@ pub struct RtSbInsVpt1VelNed1 {
     unused_variables,
 )]
 impl RtSbInsVpt1VelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9596d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9596d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_1_VEL_NED_E_MAX: f32 = 838_f32;
@@ -26057,9 +26057,9 @@ pub struct RtSbInsVpt1Offset {
     unused_variables,
 )]
 impl RtSbInsVpt1Offset {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9596c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9596c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_1_OFFSET_Z_MAX: f32 = 32.767_f32;
@@ -26284,9 +26284,9 @@ pub struct RtSbInsSlip {
     unused_variables,
 )]
 impl RtSbInsSlip {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9588222)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9588222).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_SQUAT_MIN: f32 = -360_f32;
     pub const INS_SQUAT_MAX: f32 = 360_f32;
@@ -26619,9 +26619,9 @@ pub struct RtSbInsVelEcef2 {
     unused_variables,
 )]
 impl RtSbInsVelEcef2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587f22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587f22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_ECEF_Z_MIN: f32 = -838_f32;
     pub const INS_VEL_ECEF_Z_MAX: f32 = 838_f32;
@@ -26870,9 +26870,9 @@ pub struct RtSbInsVelEcef1 {
     unused_variables,
 )]
 impl RtSbInsVelEcef1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_ECEF_X_MIN: f32 = -838_f32;
     pub const INS_VEL_ECEF_X_MAX: f32 = 838_f32;
@@ -27157,9 +27157,9 @@ pub struct RtSbInsVelNed2 {
     unused_variables,
 )]
 impl RtSbInsVelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_NED_D_MIN: f32 = -838_f32;
     pub const INS_VEL_NED_D_MAX: f32 = 838_f32;
@@ -27360,9 +27360,9 @@ pub struct RtSbInsVelNed1 {
     unused_variables,
 )]
 impl RtSbInsVelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_NED_E_MIN: f32 = -838_f32;
     pub const INS_VEL_NED_E_MAX: f32 = 838_f32;
@@ -27653,9 +27653,9 @@ pub struct RtSbInsPosEcef2 {
     unused_variables,
 )]
 impl RtSbInsPosEcef2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587122)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587122).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_ECEF_Z_MIN: f32 = -10000000_f32;
     pub const INS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
@@ -27825,9 +27825,9 @@ pub struct RtSbInsPosEcef1 {
     unused_variables,
 )]
 impl RtSbInsPosEcef1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9587022)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9587022).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_ECEF_X_MIN: f32 = -10000000_f32;
     pub const INS_POS_ECEF_X_MAX: f32 = 10000000_f32;
@@ -28194,9 +28194,9 @@ pub struct RtSbInsPosLlh2 {
     unused_variables,
 )]
 impl RtSbInsPosLlh2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9586f22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9586f22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const INS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
@@ -28365,9 +28365,9 @@ pub struct RtSbInsPosLlh1 {
     unused_variables,
 )]
 impl RtSbInsPosLlh1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9586e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9586e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const INS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
@@ -28750,9 +28750,9 @@ pub struct RtSbInsHeadingGradient2 {
     unused_variables,
 )]
 impl RtSbInsHeadingGradient2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9588122)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9588122).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_GRADIENT_MIN: f32 = -90_f32;
     pub const INS_GRADIENT_MAX: f32 = 90_f32;
@@ -29087,9 +29087,9 @@ pub struct RtSbInsHeadingGradient {
     unused_variables,
 )]
 impl RtSbInsHeadingGradient {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9588022)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9588022).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_GRADIENT_MIN: f32 = -90_f32;
     pub const INS_GRADIENT_MAX: f32 = 90_f32;
@@ -29426,9 +29426,9 @@ pub struct RtSbInsStatus {
     unused_variables,
 )]
 impl RtSbInsStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9586c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9586c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_STATUS_MIN: u8 = 0_u8;
     pub const INS_STATUS_MAX: u8 = 255_u8;
@@ -29576,9 +29576,9 @@ pub struct RtSbInsAttitude {
     unused_variables,
 )]
 impl RtSbInsAttitude {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9586d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9586d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ATTITUDE_ROLL_MIN: f32 = -360_f32;
     pub const ATTITUDE_ROLL_MAX: f32 = 360_f32;
@@ -30055,9 +30055,9 @@ pub struct RtSbOutputStatus {
     unused_variables,
 )]
 impl RtSbOutputStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9576d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9576d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_TIME_MIN: f32 = 0_f32;
     pub const GPS_TIME_MAX: f32 = 604800_f32;
@@ -30837,9 +30837,9 @@ pub struct RtSbGpsHeadingGradient2 {
     unused_variables,
 )]
 impl RtSbGpsHeadingGradient2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9568222)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9568222).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_GRADIENT_MIN: f32 = -90_f32;
     pub const GPS_GRADIENT_MAX: f32 = 90_f32;
@@ -31176,9 +31176,9 @@ pub struct RtSbCumulativeDistance2 {
     unused_variables,
 )]
 impl RtSbCumulativeDistance2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a8d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a8d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const CUMULATIVE_DISTANCE_MIN: f32 = 0_f32;
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
@@ -31424,9 +31424,9 @@ pub struct RtSbCumulativeDistance1 {
     unused_variables,
 )]
 impl RtSbCumulativeDistance1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a8c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a8c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const CUMULATIVE_DISTANCE_MIN: f32 = 0_f32;
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
@@ -31670,9 +31670,9 @@ pub struct RtSbTriggerTimestamp {
     unused_variables,
 )]
 impl RtSbTriggerTimestamp {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9576c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9576c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_HIGH_RESOLUTION_TIME_MIN: f32 = 0_f32;
     pub const GPS_HIGH_RESOLUTION_TIME_MAX: f32 = 604800_f32;
@@ -32005,9 +32005,9 @@ pub struct RtImu06GyroRates {
     unused_variables,
 )]
 impl RtImu06GyroRates {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a6d21)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a6d21).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GYRO_RATE_ROLL_MIN: f32 = -327_f32;
     pub const GYRO_RATE_ROLL_MAX: f32 = 327_f32;
@@ -32390,9 +32390,9 @@ pub struct RtImu06Accel {
     unused_variables,
 )]
 impl RtImu06Accel {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a6c21)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a6c21).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
@@ -32778,9 +32778,9 @@ pub struct RtSbSpeed {
     unused_variables,
 )]
 impl RtSbSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a7c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a7c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const SPEED_MIN: f32 = -20000_f32;
     pub const SPEED_MAX: f32 = 20000_f32;
@@ -32981,9 +32981,9 @@ pub struct RtSbRtkSlip {
     unused_variables,
 )]
 impl RtSbRtkSlip {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9568d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9568d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_BASELINE_MIN: u16 = 0_u16;
     pub const RTK_BASELINE_MAX: u16 = 65535_u16;
@@ -33356,9 +33356,9 @@ pub struct RtSbRtkAttitude {
     unused_variables,
 )]
 impl RtSbRtkAttitude {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9568c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9568c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_ATTITUDE_ROLL_MIN: f32 = -90_f32;
     pub const RTK_ATTITUDE_ROLL_MAX: f32 = 90_f32;
@@ -33741,9 +33741,9 @@ pub struct RtSbGpsMcycleLean {
     unused_variables,
 )]
 impl RtSbGpsMcycleLean {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9569c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9569c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_MCYCLE_LEAN_ANGLE_MIN: f32 = -90_f32;
     pub const GPS_MCYCLE_LEAN_ANGLE_MAX: f32 = 90_f32;
@@ -34039,9 +34039,9 @@ pub struct RtSbGpsStatus {
     unused_variables,
 )]
 impl RtSbGpsStatus {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_STATUS_MIN: u8 = 0_u8;
     pub const RTK_STATUS_MAX: u8 = 255_u8;
@@ -34563,9 +34563,9 @@ pub struct RtSbGpsPosEcef2 {
     unused_variables,
 )]
 impl RtSbGpsPosEcef2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567122)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567122).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_ECEF_Z_MIN: f32 = -10000000_f32;
     pub const GPS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
@@ -34735,9 +34735,9 @@ pub struct RtSbGpsPosEcef1 {
     unused_variables,
 )]
 impl RtSbGpsPosEcef1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567022)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567022).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_ECEF_X_MIN: f32 = -10000000_f32;
     pub const GPS_POS_ECEF_X_MAX: f32 = 10000000_f32;
@@ -35104,9 +35104,9 @@ pub struct RtSbGpsPosLlh2 {
     unused_variables,
 )]
 impl RtSbGpsPosLlh2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566f22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566f22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
@@ -35275,9 +35275,9 @@ pub struct RtSbGpsPosLlh1 {
     unused_variables,
 )]
 impl RtSbGpsPosLlh1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const GPS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
@@ -35660,9 +35660,9 @@ pub struct RtSbGpsHeadingGradient {
     unused_variables,
 )]
 impl RtSbGpsHeadingGradient {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9568122)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9568122).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_GRADIENT_MIN: f32 = -90_f32;
     pub const GPS_GRADIENT_MAX: f32 = 90_f32;
@@ -35999,9 +35999,9 @@ pub struct RtSbGpsVelEcef2 {
     unused_variables,
 )]
 impl RtSbGpsVelEcef2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9568022)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9568022).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_ECEF_Z_MIN: f32 = -838_f32;
     pub const GPS_VEL_ECEF_Z_MAX: f32 = 838_f32;
@@ -36250,9 +36250,9 @@ pub struct RtSbGpsVelEcef1 {
     unused_variables,
 )]
 impl RtSbGpsVelEcef1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567f22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567f22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_ECEF_X_MIN: f32 = -838_f32;
     pub const GPS_VEL_ECEF_X_MAX: f32 = 838_f32;
@@ -36537,9 +36537,9 @@ pub struct RtSbGpsVelNed2 {
     unused_variables,
 )]
 impl RtSbGpsVelNed2 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567e22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567e22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_NED_D_MIN: f32 = -838_f32;
     pub const GPS_VEL_NED_D_MAX: f32 = 838_f32;
@@ -36740,9 +36740,9 @@ pub struct RtSbGpsVelNed1 {
     unused_variables,
 )]
 impl RtSbGpsVelNed1 {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_NED_E_MIN: f32 = -838_f32;
     pub const GPS_VEL_NED_E_MAX: f32 = 838_f32;
@@ -37033,9 +37033,9 @@ pub struct RtSbGpsSpeed {
     unused_variables,
 )]
 impl RtSbGpsSpeed {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9567c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9567c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_SPEED_3D_MIN: f32 = 0_f32;
     pub const GPS_SPEED_3D_MAX: f32 = 1675_f32;
@@ -37324,9 +37324,9 @@ pub struct RtSbGpsTime {
     unused_variables,
 )]
 impl RtSbGpsTime {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x9566d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x9566d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_WEEK_MIN: u16 = 0_u16;
     pub const GPS_WEEK_MAX: u16 = 65535_u16;
@@ -37605,9 +37605,9 @@ pub struct RtSbAccel {
     unused_variables,
 )]
 impl RtSbAccel {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a6c22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a6c22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
@@ -37993,9 +37993,9 @@ pub struct RtSbGyroRates {
     unused_variables,
 )]
 impl RtSbGyroRates {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
-        ExtendedId::new_unchecked(0x94a6d22)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Extended(
+        ExtendedId::new(0x94a6d22).unwrap(),
+    );
     pub const MESSAGE_SIZE: usize = 8;
     pub const GYRO_RATE_ROLL_MIN: f32 = -327_f32;
     pub const GYRO_RATE_ROLL_MAX: f32 = 327_f32;

--- a/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
+++ b/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
@@ -68,9 +68,7 @@ pub struct TestInput {
     unused_variables,
 )]
 impl TestInput {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x0)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x0).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_INPUT_MUX_MIN: u8 = 0_u8;
     pub const TEST_INPUT_MUX_MAX: u8 = 0_u8;
@@ -558,9 +556,7 @@ pub struct TestOutput {
     unused_variables,
 )]
 impl TestOutput {
-    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
-        StandardId::new_unchecked(0x1)
-    });
+    pub const MESSAGE_ID: embedded_can::Id = Id::Standard(StandardId::new(0x1).unwrap());
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_OUTPUT_MUX_MIN: u8 = 0_u8;
     pub const TEST_OUTPUT_MUX_MAX: u8 = 0_u8;


### PR DESCRIPTION
Replaces unsafe code in the generated `MESSAGE_ID` constants with `<StandardId/ExtendedId>::new(...).unwrap()`. `Option::unwrap()` has been available in `const` contexts since Rust 1.83 (the current MSRV is 1.88).

The generated code no longer contains any unsafe blocks after this change.

